### PR TITLE
Moved getter for cache value to inside the try catch

### DIFF
--- a/Directory.build.props
+++ b/Directory.build.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <LangVersion>8.0</LangVersion>
-    <Version>4.0.0-beta09</Version>
+    <Version>4.0.0-beta10</Version>
   </PropertyGroup>
   <PropertyGroup>
     <Authors>Norsk Helsenett SF</Authors>

--- a/src/Helsenorge.Registries/Utilities/CacheExtensions.cs
+++ b/src/Helsenorge.Registries/Utilities/CacheExtensions.cs
@@ -11,9 +11,10 @@ namespace Helsenorge.Registries.Utilities
     {
         public static async Task<T> ReadValueFromCache<T>(ILogger logger, IDistributedCache cache, string key) where T : class
         {
-            var cached = await cache.GetAsync(key).ConfigureAwait(false);
             try
             {
+                var cached = await cache.GetAsync(key).ConfigureAwait(false);
+
                 if (cached is null)
                     return default;
                 


### PR DESCRIPTION
Moved the method that retrives cached values to inside the try in try catch. If it fails retriving value from the cache will the application not crash and it will get new values and write new cache.