### PR TITLE
Certification type determined by keyusage

### DIFF
--- a/Directory.build.props
+++ b/Directory.build.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <LangVersion>8.0</LangVersion>
-    <Version>4.0.0-beta10</Version>
+    <Version>4.0.0-beta11</Version>
   </PropertyGroup>
   <PropertyGroup>
     <Authors>Norsk Helsenett SF</Authors>


### PR DESCRIPTION
If it's signing or encryption certificate is now determind by the keyusage information that's on the certificate. Instead of using the certId attribute in the XML.