### PR TITLE
Certification type determined by keyusage

### DIFF
--- a/Directory.build.props
+++ b/Directory.build.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <LangVersion>8.0</LangVersion>
-    <Version>4.0.0-beta10</Version>
+    <Version>4.0.0-beta11</Version>
   </PropertyGroup>
   <PropertyGroup>
     <Authors>Norsk Helsenett SF</Authors>

--- a/src/Helsenorge.Registries/CertificateValidator.cs
+++ b/src/Helsenorge.Registries/CertificateValidator.cs
@@ -42,19 +42,8 @@ namespace Helsenorge.Registries
                 result |= CertificateErrors.EndDate;
             }
 
-            foreach (var extension in certificate.Extensions)
-            {
-                switch (extension.Oid.Value)
-                {
-                    case "2.5.29.15": // Key usage
-                        var usageExtension = (X509KeyUsageExtension)extension;
-                        if ((usageExtension.KeyUsages & usage) != usage)
-                        {
-                            result |= CertificateErrors.Usage;
-                        }
-                        break;
-                }
-            }
+            if(!certificate.HasKeyUsage(usage))
+                result |= CertificateErrors.Usage;
 
             var chain = new X509Chain
             {

--- a/src/Helsenorge.Registries/CollaborationProtocolRegistry.cs
+++ b/src/Helsenorge.Registries/CollaborationProtocolRegistry.cs
@@ -325,9 +325,13 @@ namespace Helsenorge.Registries
                 var x509Certificate = new X509Certificate2(Convert.FromBase64String(base64));
 
                 if (x509Certificate.HasKeyUsage(X509KeyUsageFlags.DataEncipherment))
+                {
                     cpa.EncryptionCertificate = x509Certificate;
+                }
                 else if (x509Certificate.HasKeyUsage(X509KeyUsageFlags.NonRepudiation))
+                {
                     cpa.SignatureCertificate = x509Certificate;
+                }
             }
             return cpa;
         }

--- a/src/Helsenorge.Registries/CollaborationProtocolRegistry.cs
+++ b/src/Helsenorge.Registries/CollaborationProtocolRegistry.cs
@@ -322,18 +322,16 @@ namespace Helsenorge.Registries
             {
                 var id = certificate.Attribute(_ns + "certId").Value;
                 var base64 = certificate.Descendants(xmlSig + "X509Certificate").First().Value;
+                var x509Certificate = new X509Certificate2(Convert.FromBase64String(base64));
 
-                if (id.Equals("enc", StringComparison.Ordinal))
-                {
-                    cpa.EncryptionCertificate = new X509Certificate2(Convert.FromBase64String(base64));
-                }
-                else
-                {
-                    cpa.SignatureCertificate = new X509Certificate2(Convert.FromBase64String(base64));
-                }
+                if (x509Certificate.HasKeyUsage(X509KeyUsageFlags.DataEncipherment))
+                    cpa.EncryptionCertificate = x509Certificate;
+                else if (x509Certificate.HasKeyUsage(X509KeyUsageFlags.NonRepudiation))
+                    cpa.SignatureCertificate = x509Certificate;
             }
             return cpa;
         }
+
         private CollaborationProtocolRole CreateFromCollaborationRole(XContainer element, XElement partyInfo)
         {
             if (element == null) throw new ArgumentNullException(nameof(element));

--- a/src/Helsenorge.Registries/X509Certificate2Extensions.cs
+++ b/src/Helsenorge.Registries/X509Certificate2Extensions.cs
@@ -1,0 +1,26 @@
+﻿using System.Security.Cryptography.X509Certificates;
+
+namespace Helsenorge.Registries
+{
+    internal static class X509Certificate2Extensions
+    {
+        internal static bool HasKeyUsage(this X509Certificate2 certificate, X509KeyUsageFlags keyUsage)
+        {
+            foreach (var extension in certificate.Extensions)
+            {
+                switch (extension.Oid.Value)
+                {
+                    case "2.5.29.15": // Key usage
+                        var usageExtension = (X509KeyUsageExtension)extension;
+                        if ((usageExtension.KeyUsages & keyUsage) == keyUsage)
+                        {
+                            return true;
+                        }
+                        break;
+                }
+            }
+
+            return false;
+        }
+    }
+}

--- a/test/Helsenorge.Registries.Tests/CertificateValidatorTests.cs
+++ b/test/Helsenorge.Registries.Tests/CertificateValidatorTests.cs
@@ -50,6 +50,13 @@ namespace Helsenorge.Registries.Tests
                 X509KeyUsageFlags.DataEncipherment);
             Assert.AreEqual(CertificateErrors.Usage, error);
         }
+        [TestMethod]
+        [TestCategory("X509Chain")]
+        public void X509Certificate2Extensions_KeyUsage()
+        {
+            Assert.IsTrue(TestCertificates.CounterpartyPublicSignature.HasKeyUsage(X509KeyUsageFlags.NonRepudiation));
+            Assert.IsFalse(TestCertificates.CounterpartyPublicSignature.HasKeyUsage(X509KeyUsageFlags.DataEncipherment));
+        }
         // don't have a certificate with multiple errors
         //[TestMethod]
         //public void CertificateValidation_Multiple()


### PR DESCRIPTION
If it's signing or encryption certificate is now determind by the keyusage information that's on the certificate. Instead of using the certId attribute in the XML.