### PR TITLE
Fixed issues with cloning message and setting custom message properties

### DIFF
--- a/Directory.build.props
+++ b/Directory.build.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <LangVersion>8.0</LangVersion>
-    <Version>4.0.1-beta01</Version>
+    <Version>4.0.0-beta12</Version>
   </PropertyGroup>
   <PropertyGroup>
     <Authors>Norsk Helsenett SF</Authors>

--- a/Directory.build.props
+++ b/Directory.build.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <LangVersion>8.0</LangVersion>
-    <Version>4.0.0-beta11</Version>
+    <Version>4.0.1-beta01</Version>
   </PropertyGroup>
   <PropertyGroup>
     <Authors>Norsk Helsenett SF</Authors>

--- a/src/Helsenorge.Messaging/Abstractions/IMessagingMessage.cs
+++ b/src/Helsenorge.Messaging/Abstractions/IMessagingMessage.cs
@@ -114,5 +114,18 @@ namespace Helsenorge.Messaging.Abstractions
         /// Gets the number of deliveries.
         /// </summary>
         int DeliveryCount { get; }
+        /// <summary>
+        /// Set additional properties related to the message
+        /// </summary>
+        void SetProperty(string key, string value);
+        /// <summary>
+        /// Set additional properties related to the message
+        /// </summary>
+        void SetProperty(string key, DateTime value);
+        /// <summary>
+        /// Set additional properties related to the message
+        /// </summary>
+        void SetProperty(string key, int value);
+
     }
 }

--- a/src/Helsenorge.Messaging/Abstractions/IMessagingMessage.cs
+++ b/src/Helsenorge.Messaging/Abstractions/IMessagingMessage.cs
@@ -117,15 +117,15 @@ namespace Helsenorge.Messaging.Abstractions
         /// <summary>
         /// Set additional properties related to the message
         /// </summary>
-        void SetProperty(string key, string value);
+        void SetApplicationProperty(string key, string value);
         /// <summary>
         /// Set additional properties related to the message
         /// </summary>
-        void SetProperty(string key, DateTime value);
+        void SetApplicationProperty(string key, DateTime value);
         /// <summary>
         /// Set additional properties related to the message
         /// </summary>
-        void SetProperty(string key, int value);
+        void SetApplicationProperty(string key, int value);
 
     }
 }

--- a/src/Helsenorge.Messaging/ServiceBus/ServiceBusMessage.cs
+++ b/src/Helsenorge.Messaging/ServiceBus/ServiceBusMessage.cs
@@ -46,27 +46,27 @@ namespace Helsenorge.Messaging.ServiceBus
             [DebuggerStepThrough]
             get => GetProperty(ServiceBusCore.FromHerIdHeaderKey, 0);
             [DebuggerStepThrough]
-            set => SetProperty(ServiceBusCore.FromHerIdHeaderKey, value);
+            set => SetApplicationProperty(ServiceBusCore.FromHerIdHeaderKey, value);
         }
         public int ToHerId
         {
             [DebuggerStepThrough]
             get => GetProperty(ServiceBusCore.ToHerIdHeaderKey, 0);
             [DebuggerStepThrough]
-            set => SetProperty(ServiceBusCore.ToHerIdHeaderKey, value);
+            set => SetApplicationProperty(ServiceBusCore.ToHerIdHeaderKey, value);
         }
         public DateTime ApplicationTimestamp
         {
             get => GetProperty(ServiceBusCore.ApplicationTimestampHeaderKey, DateTime.MinValue);
             [DebuggerStepThrough]
-            set => SetProperty(ServiceBusCore.ApplicationTimestampHeaderKey, value);
+            set => SetApplicationProperty(ServiceBusCore.ApplicationTimestampHeaderKey, value);
         }
         public string CpaId
         {
             [DebuggerStepThrough]
             get => GetProperty(ServiceBusCore.CpaIdHeaderKey, string.Empty);
             [DebuggerStepThrough]
-            set => SetProperty(ServiceBusCore.CpaIdHeaderKey, value);
+            set => SetApplicationProperty(ServiceBusCore.CpaIdHeaderKey, value);
         }
         public object OriginalObject => _implementation;
 
@@ -314,9 +314,9 @@ namespace Helsenorge.Messaging.ServiceBus
             }
         }
 
-        public void SetProperty(string key, string value) => GetApplicationProperties()[key] = value;
-        public void SetProperty(string key, DateTime value) => GetApplicationProperties()[key] = value.ToString(StringFormatConstants.IsoDateTime, DateTimeFormatInfo.InvariantInfo);
-        public void SetProperty(string key, int value) => GetApplicationProperties()[key] = value.ToString(CultureInfo.InvariantCulture);
+        public void SetApplicationProperty(string key, string value) => GetApplicationProperties()[key] = value;
+        public void SetApplicationProperty(string key, DateTime value) => GetApplicationProperties()[key] = value.ToString(StringFormatConstants.IsoDateTime, DateTimeFormatInfo.InvariantInfo);
+        public void SetApplicationProperty(string key, int value) => GetApplicationProperties()[key] = value.ToString(CultureInfo.InvariantCulture);
 
         private string GetProperty(string key, string value) => GetApplicationProperties()?.Map.ContainsKey(key) == true
             ? GetApplicationProperties()[key].ToString()

--- a/src/Helsenorge.Messaging/ServiceBus/ServiceBusMessage.cs
+++ b/src/Helsenorge.Messaging/ServiceBus/ServiceBusMessage.cs
@@ -44,27 +44,27 @@ namespace Helsenorge.Messaging.ServiceBus
         public int FromHerId
         {
             [DebuggerStepThrough]
-            get => GetProperty(ServiceBusCore.FromHerIdHeaderKey, 0);
+            get => GetValue(ServiceBusCore.FromHerIdHeaderKey, 0);
             [DebuggerStepThrough]
             set => SetApplicationProperty(ServiceBusCore.FromHerIdHeaderKey, value);
         }
         public int ToHerId
         {
             [DebuggerStepThrough]
-            get => GetProperty(ServiceBusCore.ToHerIdHeaderKey, 0);
+            get => GetValue(ServiceBusCore.ToHerIdHeaderKey, 0);
             [DebuggerStepThrough]
             set => SetApplicationProperty(ServiceBusCore.ToHerIdHeaderKey, value);
         }
         public DateTime ApplicationTimestamp
         {
-            get => GetProperty(ServiceBusCore.ApplicationTimestampHeaderKey, DateTime.MinValue);
+            get => GetValue(ServiceBusCore.ApplicationTimestampHeaderKey, DateTime.MinValue);
             [DebuggerStepThrough]
             set => SetApplicationProperty(ServiceBusCore.ApplicationTimestampHeaderKey, value);
         }
         public string CpaId
         {
             [DebuggerStepThrough]
-            get => GetProperty(ServiceBusCore.CpaIdHeaderKey, string.Empty);
+            get => GetValue(ServiceBusCore.CpaIdHeaderKey, string.Empty);
             [DebuggerStepThrough]
             set => SetApplicationProperty(ServiceBusCore.CpaIdHeaderKey, value);
         }
@@ -318,14 +318,14 @@ namespace Helsenorge.Messaging.ServiceBus
         public void SetApplicationProperty(string key, DateTime value) => GetApplicationProperties()[key] = value.ToString(StringFormatConstants.IsoDateTime, DateTimeFormatInfo.InvariantInfo);
         public void SetApplicationProperty(string key, int value) => GetApplicationProperties()[key] = value.ToString(CultureInfo.InvariantCulture);
 
-        private string GetProperty(string key, string value) => GetApplicationProperties()?.Map.ContainsKey(key) == true
+        private string GetValue(string key, string value) => GetApplicationProperties()?.Map.ContainsKey(key) == true
             ? GetApplicationProperties()[key].ToString()
             : value;
 
-        private int GetProperty(string key, int value) => GetApplicationProperties()?.Map.ContainsKey(key) == true
+        private int GetValue(string key, int value) => GetApplicationProperties()?.Map.ContainsKey(key) == true
             ? int.Parse(GetApplicationProperties()[key].ToString())
             : value;
-        private DateTime GetProperty(string key, DateTime value) => GetApplicationProperties()?.Map.ContainsKey(key) == true
+        private DateTime GetValue(string key, DateTime value) => GetApplicationProperties()?.Map.ContainsKey(key) == true
             ? DateTime.Parse(GetApplicationProperties()[key].ToString(), CultureInfo.InvariantCulture)
             : value;
         

--- a/test/Helsenorge.Messaging.Tests/Mocks/MockMessage.cs
+++ b/test/Helsenorge.Messaging.Tests/Mocks/MockMessage.cs
@@ -117,17 +117,17 @@ namespace Helsenorge.Messaging.Tests.Mocks
         
         }
 
-        public void SetProperty(string key, string value)
+        public void SetApplicationProperty(string key, string value)
         {
             Properties[key] = value;
         }
 
-        public void SetProperty(string key, DateTime value)
+        public void SetApplicationProperty(string key, DateTime value)
         {
             Properties[key] = value.ToString(StringFormatConstants.IsoDateTime, DateTimeFormatInfo.InvariantInfo);
         }
 
-        public void SetProperty(string key, int value)
+        public void SetApplicationProperty(string key, int value)
         {
             Properties[key] = value.ToString(CultureInfo.InvariantCulture);
         }

--- a/test/Helsenorge.Messaging.Tests/Mocks/MockMessage.cs
+++ b/test/Helsenorge.Messaging.Tests/Mocks/MockMessage.cs
@@ -34,7 +34,7 @@ namespace Helsenorge.Messaging.Tests.Mocks
         public string CpaId { get; set; }
         public DateTime EnqueuedTimeUtc { get; } = DateTime.Now;
         public DateTime ExpiresAtUtc { get; } = DateTime.Now.AddMinutes(5);
-        public IDictionary<string, object> Properties { get; set; }
+        public IDictionary<string, object> Properties { get; private set; }
         public long Size => _stream.Length;
         public string ContentType { get; set; }
         public string CorrelationId { get; set; }

--- a/test/Helsenorge.Messaging.Tests/Mocks/MockMessage.cs
+++ b/test/Helsenorge.Messaging.Tests/Mocks/MockMessage.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using Helsenorge.Messaging.Abstractions;
 using System.IO;
 using System.Xml.Linq;
+using System.Globalization;
 
 namespace Helsenorge.Messaging.Tests.Mocks
 {
@@ -33,7 +34,7 @@ namespace Helsenorge.Messaging.Tests.Mocks
         public string CpaId { get; set; }
         public DateTime EnqueuedTimeUtc { get; } = DateTime.Now;
         public DateTime ExpiresAtUtc { get; } = DateTime.Now.AddMinutes(5);
-        public IDictionary<string, object> Properties { get; private set; }
+        public IDictionary<string, object> Properties { get; set; }
         public long Size => _stream.Length;
         public string ContentType { get; set; }
         public string CorrelationId { get; set; }
@@ -114,6 +115,21 @@ namespace Helsenorge.Messaging.Tests.Mocks
         public void AddDetailsToException(Exception ex)
         {
         
+        }
+
+        public void SetProperty(string key, string value)
+        {
+            Properties[key] = value;
+        }
+
+        public void SetProperty(string key, DateTime value)
+        {
+            Properties[key] = value.ToString(StringFormatConstants.IsoDateTime, DateTimeFormatInfo.InvariantInfo);
+        }
+
+        public void SetProperty(string key, int value)
+        {
+            Properties[key] = value.ToString(CultureInfo.InvariantCulture);
         }
     }
 }

--- a/test/Helsenorge.Messaging.Tests/ServiceBus/ServiceBusMessageTests.cs
+++ b/test/Helsenorge.Messaging.Tests/ServiceBus/ServiceBusMessageTests.cs
@@ -3,6 +3,8 @@ using Amqp.Framing;
 using Helsenorge.Messaging.ServiceBus;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
+using System.Globalization;
+using System.IO;
 
 namespace Helsenorge.Messaging.Tests.ServiceBus
 {
@@ -97,6 +99,27 @@ namespace Helsenorge.Messaging.Tests.ServiceBus
         }
 
         [TestMethod]
+        public void Should_Return_Custom_ApplicationProperties()
+        {
+            int customProperty1 = 1;
+            int customPropert1Change = 4;
+            string customProperty2 = "Value 2";
+            DateTime customProperty3 = DateTime.Now;
+
+            using ServiceBusMessage message = new ServiceBusMessage(new Message());
+            message.SetProperty("CustomProperty1", customProperty1);
+            message.SetProperty("CustomProperty2", customProperty2);
+            message.SetProperty("CustomProperty3", customProperty3);
+
+            Assert.AreEqual(customProperty1.ToString(CultureInfo.InvariantCulture), message.Properties["CustomProperty1"]);
+            Assert.AreEqual(customProperty2, message.Properties["CustomProperty2"]);
+            Assert.AreEqual(customProperty3.ToString(StringFormatConstants.IsoDateTime, DateTimeFormatInfo.InvariantInfo), message.Properties["CustomProperty3"]);
+
+            message.Properties["CustomProperty1"] = customPropert1Change;
+            Assert.AreNotEqual(customPropert1Change, message.Properties["CustomProperty1"]);
+        }
+
+        [TestMethod]
         public void Should_Return_All_Initialized_Properties()
         {
             string contentType = "contentType_value";
@@ -140,10 +163,7 @@ namespace Helsenorge.Messaging.Tests.ServiceBus
             string to = "to_value";
             TimeSpan ttl = TimeSpan.FromDays(4);
             DateTime scheduledEnqueueTimeUtc = DateTime.UtcNow;
-            Data data = new Data
-            {
-                Binary = new byte[] { 255, 0, 255 }
-            };
+            byte[] data = new byte[] { 255, 0, 255 };
 
             using (ServiceBusMessage message = new ServiceBusMessage(new Message(data)))
             {
@@ -178,11 +198,31 @@ namespace Helsenorge.Messaging.Tests.ServiceBus
                 Assert.IsNotNull(((Message)clonedMessage.OriginalObject).Body);
                 Assert.IsInstanceOfType(((Message)clonedMessage.OriginalObject).BodySection, typeof(Data));
                 Data dataClone = (Data)((Message)clonedMessage.OriginalObject).BodySection;
-                Assert.AreEqual(data.Binary.Length, dataClone.Binary.Length);
-                Assert.AreEqual(data.Binary[0], dataClone.Binary[0]);
-                Assert.AreEqual(data.Binary[1], dataClone.Binary[1]);
-                Assert.AreEqual(data.Binary[2], dataClone.Binary[2]);
+                Assert.AreEqual(data.Length, dataClone.Binary.Length);
+                Assert.AreEqual(data[0], dataClone.Binary[0]);
+                Assert.AreEqual(data[1], dataClone.Binary[1]);
+                Assert.AreEqual(data[2], dataClone.Binary[2]);
             }
+        }
+
+        [TestMethod]
+        public void Should_Return_Cloned_Message_When_Payload_Is_Stream()
+        {
+            using MemoryStream data = new MemoryStream(new byte[] { 255, 0, 255 });
+            using ServiceBusMessage message = new ServiceBusMessage(new Message(data));
+            var clonedMessage = message.Clone();
+
+            Assert.IsNotNull(((Message)clonedMessage.OriginalObject).Body);
+            Assert.IsInstanceOfType(((Message)clonedMessage.OriginalObject).BodySection, typeof(Data));
+            Data dataClone = (Data)((Message)clonedMessage.OriginalObject).BodySection;
+
+            data.Position = 0;
+            byte[] dataBinary = data.ToArray();
+
+            Assert.AreEqual(dataBinary.Length, dataClone.Binary.Length);
+            Assert.AreEqual(dataBinary[0], dataClone.Binary[0]);
+            Assert.AreEqual(dataBinary[1], dataClone.Binary[1]);
+            Assert.AreEqual(dataBinary[2], dataClone.Binary[2]);
         }
 
         [TestMethod]
@@ -202,10 +242,7 @@ namespace Helsenorge.Messaging.Tests.ServiceBus
             TimeSpan ttl = TimeSpan.FromDays(4);
             DateTime scheduledEnqueueTimeUtc = DateTime.UtcNow;
 
-            Data data = new Data
-            {
-                Binary = new byte[] { 255, 0, 255 }
-            };
+            byte[] data =  new byte[] { 255, 0, 255 };
 
             using (ServiceBusMessage message = new ServiceBusMessage(new Message(data)))
             {

--- a/test/Helsenorge.Messaging.Tests/ServiceBus/ServiceBusMessageTests.cs
+++ b/test/Helsenorge.Messaging.Tests/ServiceBus/ServiceBusMessageTests.cs
@@ -107,9 +107,9 @@ namespace Helsenorge.Messaging.Tests.ServiceBus
             DateTime customProperty3 = DateTime.Now;
 
             using ServiceBusMessage message = new ServiceBusMessage(new Message());
-            message.SetProperty("CustomProperty1", customProperty1);
-            message.SetProperty("CustomProperty2", customProperty2);
-            message.SetProperty("CustomProperty3", customProperty3);
+            message.SetApplicationProperty("CustomProperty1", customProperty1);
+            message.SetApplicationProperty("CustomProperty2", customProperty2);
+            message.SetApplicationProperty("CustomProperty3", customProperty3);
 
             Assert.AreEqual(customProperty1.ToString(CultureInfo.InvariantCulture), message.Properties["CustomProperty1"]);
             Assert.AreEqual(customProperty2, message.Properties["CustomProperty2"]);


### PR DESCRIPTION
There was two issues related to the implementation of AMQP.net Lite library, where how you do cloning and setting of properties has been changed.
- Cloning of message did not include payload
- Creating new properties on a message on a message through the exposed "Properties" property no longer worked

These issues has been fixed. A new method for setting the message properties has been introduced, "SetProperty" can now be used for this.