### PR TITLE
Exposing Proxy settings in WcfConfiguration file

### DIFF
--- a/Directory.build.props
+++ b/Directory.build.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <LangVersion>8.0</LangVersion>
-    <Version>4.0.0-beta16</Version>
+    <Version>4.0.0-beta15</Version>
   </PropertyGroup>
   <PropertyGroup>
     <Authors>Norsk Helsenett SF</Authors>

--- a/Directory.build.props
+++ b/Directory.build.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <LangVersion>8.0</LangVersion>
-    <Version>4.0.0-beta15</Version>
+    <Version>4.0.0-beta16</Version>
   </PropertyGroup>
   <PropertyGroup>
     <Authors>Norsk Helsenett SF</Authors>

--- a/src/Helsenorge.Registries/Configuration/ConfigurationChannelFactory.cs
+++ b/src/Helsenorge.Registries/Configuration/ConfigurationChannelFactory.cs
@@ -74,10 +74,21 @@ namespace Helsenorge.Registries.Configuration
                         {
                             basicHttpBinding.MaxBufferPoolSize = configuration.MaxBufferPoolSize;
                         }
-
                         if (configuration.MaxReceivedMessageSize > 0)
                         {
                             basicHttpBinding.MaxReceivedMessageSize = configuration.MaxReceivedMessageSize;
+                        }
+                        if (configuration.UseDefaultWebProxy != default(bool))
+                        {
+                            basicHttpBinding.UseDefaultWebProxy = configuration.UseDefaultWebProxy;
+                        }
+                        if (configuration.BypassProxyOnLocal != default(bool))
+                        {
+                            basicHttpBinding.BypassProxyOnLocal = configuration.BypassProxyOnLocal;
+                        }
+                        if (configuration.ProxyAddress != default(Uri))
+                        {
+                            basicHttpBinding.ProxyAddress = configuration.ProxyAddress;
                         }
                         return basicHttpBinding;
 
@@ -91,6 +102,18 @@ namespace Helsenorge.Registries.Configuration
                         if (configuration.MaxReceivedMessageSize > 0)
                         {
                             wsHttpBinding.MaxReceivedMessageSize = configuration.MaxReceivedMessageSize;
+                        }
+                        if (configuration.UseDefaultWebProxy != default)
+                        {
+                            wsHttpBinding.UseDefaultWebProxy = configuration.UseDefaultWebProxy;
+                        }
+                        if (configuration.BypassProxyOnLocal != default)
+                        {
+                            wsHttpBinding.BypassProxyOnLocal = configuration.BypassProxyOnLocal;
+                        }
+                        if (configuration.ProxyAddress != default)
+                        {
+                            wsHttpBinding.ProxyAddress = configuration.ProxyAddress;
                         }
                         return wsHttpBinding;
                 }

--- a/src/Helsenorge.Registries/Configuration/ConfigurationChannelFactory.cs
+++ b/src/Helsenorge.Registries/Configuration/ConfigurationChannelFactory.cs
@@ -78,15 +78,15 @@ namespace Helsenorge.Registries.Configuration
                         {
                             basicHttpBinding.MaxReceivedMessageSize = configuration.MaxReceivedMessageSize;
                         }
-                        if (configuration.UseDefaultWebProxy != default(bool))
+                        if (configuration.UseDefaultWebProxy != default)
                         {
                             basicHttpBinding.UseDefaultWebProxy = configuration.UseDefaultWebProxy;
                         }
-                        if (configuration.BypassProxyOnLocal != default(bool))
+                        if (configuration.BypassProxyOnLocal != default)
                         {
                             basicHttpBinding.BypassProxyOnLocal = configuration.BypassProxyOnLocal;
                         }
-                        if (configuration.ProxyAddress != default(Uri))
+                        if (configuration.ProxyAddress != default)
                         {
                             basicHttpBinding.ProxyAddress = configuration.ProxyAddress;
                         }

--- a/src/Helsenorge.Registries/Configuration/WcfConfiguration.cs
+++ b/src/Helsenorge.Registries/Configuration/WcfConfiguration.cs
@@ -1,10 +1,11 @@
 ﻿/* 
- * Copyright (c) 2020, Norsk Helsenett SF and contributors
  * See the file CONTRIBUTORS for details.
  * 
  * This file is licensed under the MIT license
  * available at https://raw.githubusercontent.com/helsenorge/Helsenorge.Messaging/master/LICENSE
  */
+
+using System;
 
 namespace Helsenorge.Registries.Configuration
 {
@@ -32,6 +33,12 @@ namespace Helsenorge.Registries.Configuration
         public int MaxBufferPoolSize { get; set; }
 
         public int MaxReceivedMessageSize { get; set; }
+        
+        public bool UseDefaultWebProxy { get; internal set; }
+        
+        public bool BypassProxyOnLocal { get; internal set; }
+        
+        public Uri ProxyAddress { get; internal set; }
     }
 
     public enum WcfHttpBinding

--- a/test/Helsenorge.Registries.Tests/Configuration/ConfigurationChannelFactoryTests.cs
+++ b/test/Helsenorge.Registries.Tests/Configuration/ConfigurationChannelFactoryTests.cs
@@ -56,6 +56,9 @@ namespace Helsenorge.Registries.Tests.Configuration
             Assert.Equal(HttpClientCredentialType.Basic, binding.Security.Transport.ClientCredentialType);
             Assert.Null(factory.Credentials?.UserName.UserName);
             Assert.Null(factory.Credentials?.UserName.Password);
+            Assert.Equal(default(Uri), binding.ProxyAddress);
+            Assert.False(binding.BypassProxyOnLocal);
+            Assert.False(binding.UseDefaultWebProxy);
         }
 
         [Fact]
@@ -68,7 +71,10 @@ namespace Helsenorge.Registries.Tests.Configuration
                 Password = "pass",
                 MaxBufferSize = 1001,
                 MaxBufferPoolSize = 2001,
-                MaxReceivedMessageSize = 30001
+                MaxReceivedMessageSize = 30001,
+                ProxyAddress = new Uri("http://test.test"),
+                BypassProxyOnLocal = true,
+                UseDefaultWebProxy = true
             });
             var binding = factory.Endpoint.Binding as BasicHttpBinding;
             Assert.NotNull(binding);
@@ -82,6 +88,9 @@ namespace Helsenorge.Registries.Tests.Configuration
             Assert.NotNull(factory.Credentials?.UserName.Password);
             Assert.Equal("user", factory.Credentials.UserName.UserName);
             Assert.Equal("pass", factory.Credentials.UserName.Password);
+            Assert.Equal(new Uri("http://test.test").AbsoluteUri, binding.ProxyAddress.AbsoluteUri);
+            Assert.True(binding.BypassProxyOnLocal);
+            Assert.True(binding.UseDefaultWebProxy);
         }
 
         [Fact]


### PR DESCRIPTION
Exposing the properties UseDefaultWebProxy, BypassProxyOnLocal and ProxyAddress so these can be set.