### PR TITLE
Exposed property for proxy so they can be set

### DIFF
--- a/Directory.build.props
+++ b/Directory.build.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <LangVersion>8.0</LangVersion>
-    <Version>4.0.0-beta16</Version>
+    <Version>4.0.0-beta17</Version>
   </PropertyGroup>
   <PropertyGroup>
     <Authors>Norsk Helsenett SF</Authors>

--- a/src/Helsenorge.Registries/Configuration/WcfConfiguration.cs
+++ b/src/Helsenorge.Registries/Configuration/WcfConfiguration.cs
@@ -34,11 +34,11 @@ namespace Helsenorge.Registries.Configuration
 
         public int MaxReceivedMessageSize { get; set; }
         
-        public bool UseDefaultWebProxy { get; internal set; }
+        public bool UseDefaultWebProxy { get; set; }
         
-        public bool BypassProxyOnLocal { get; internal set; }
+        public bool BypassProxyOnLocal { get; set; }
         
-        public Uri ProxyAddress { get; internal set; }
+        public Uri ProxyAddress { get; set; }
     }
 
     public enum WcfHttpBinding


### PR DESCRIPTION
Property for proxy had internal set which has been changed to public.
This is so they can be changed and set by config.