### PR TITLE
Fixed so UseDefaultWebProxy can be set to false

### DIFF
--- a/src/Helsenorge.Registries/Configuration/ConfigurationChannelFactory.cs
+++ b/src/Helsenorge.Registries/Configuration/ConfigurationChannelFactory.cs
@@ -44,17 +44,17 @@ namespace Helsenorge.Registries.Configuration
             {
                 var netTcpBinding = new NetTcpBinding(SecurityMode.TransportWithMessageCredential);
                 netTcpBinding.Security.Message.ClientCredentialType = MessageCredentialType.UserName;
-                if (configuration.MaxBufferSize > 0)
+                if (configuration.MaxBufferSize != default)
                 {
-                    netTcpBinding.MaxBufferSize = configuration.MaxBufferSize;
+                    netTcpBinding.MaxBufferSize = configuration.MaxBufferSize.GetValueOrDefault();
                 }
-                if (configuration.MaxBufferPoolSize > 0)
+                if (configuration.MaxBufferPoolSize != default)
                 {
-                    netTcpBinding.MaxBufferPoolSize = configuration.MaxBufferPoolSize;
+                    netTcpBinding.MaxBufferPoolSize = configuration.MaxBufferPoolSize.GetValueOrDefault();
                 }
-                if (configuration.MaxReceivedMessageSize > 0)
+                if (configuration.MaxReceivedMessageSize != default)
                 {
-                    netTcpBinding.MaxReceivedMessageSize = configuration.MaxReceivedMessageSize;
+                    netTcpBinding.MaxReceivedMessageSize = configuration.MaxReceivedMessageSize.GetValueOrDefault();
                 }
                 return netTcpBinding;
             }
@@ -66,25 +66,25 @@ namespace Helsenorge.Registries.Configuration
                     case WcfHttpBinding.Basic:
                         var basicHttpBinding = new BasicHttpBinding(BasicHttpSecurityMode.Transport);
                         basicHttpBinding.Security.Transport.ClientCredentialType = HttpClientCredentialType.Basic;
-                        if (configuration.MaxBufferSize > 0)
+                        if (configuration.MaxBufferSize != default)
                         {
-                            basicHttpBinding.MaxBufferSize = configuration.MaxBufferSize;
+                            basicHttpBinding.MaxBufferSize = configuration.MaxBufferSize.GetValueOrDefault();
                         }
-                        if (configuration.MaxBufferPoolSize > 0)
+                        if (configuration.MaxBufferPoolSize != default)
                         {
-                            basicHttpBinding.MaxBufferPoolSize = configuration.MaxBufferPoolSize;
+                            basicHttpBinding.MaxBufferPoolSize = configuration.MaxBufferPoolSize.GetValueOrDefault();
                         }
-                        if (configuration.MaxReceivedMessageSize > 0)
+                        if (configuration.MaxReceivedMessageSize != default)
                         {
-                            basicHttpBinding.MaxReceivedMessageSize = configuration.MaxReceivedMessageSize;
+                            basicHttpBinding.MaxReceivedMessageSize = configuration.MaxReceivedMessageSize.GetValueOrDefault();
                         }
-                        if (configuration.UseDefaultWebProxy != default)
+                        if (configuration.UseDefaultWebProxy != default) 
                         {
-                            basicHttpBinding.UseDefaultWebProxy = configuration.UseDefaultWebProxy;
+                            basicHttpBinding.UseDefaultWebProxy = configuration.UseDefaultWebProxy.GetValueOrDefault();
                         }
                         if (configuration.BypassProxyOnLocal != default)
                         {
-                            basicHttpBinding.BypassProxyOnLocal = configuration.BypassProxyOnLocal;
+                            basicHttpBinding.BypassProxyOnLocal = configuration.BypassProxyOnLocal.GetValueOrDefault();
                         }
                         if (configuration.ProxyAddress != default)
                         {
@@ -95,21 +95,21 @@ namespace Helsenorge.Registries.Configuration
                     case WcfHttpBinding.WsHttp:
                         var wsHttpBinding = new WSHttpBinding(SecurityMode.Transport);
                         wsHttpBinding.Security.Transport.ClientCredentialType = HttpClientCredentialType.Basic;
-                        if (configuration.MaxBufferPoolSize > 0)
+                        if (configuration.MaxBufferPoolSize != default)
                         {
-                            wsHttpBinding.MaxBufferPoolSize = configuration.MaxBufferPoolSize;
+                            wsHttpBinding.MaxBufferPoolSize = configuration.MaxBufferPoolSize.GetValueOrDefault();
                         }
-                        if (configuration.MaxReceivedMessageSize > 0)
+                        if (configuration.MaxReceivedMessageSize != default)
                         {
-                            wsHttpBinding.MaxReceivedMessageSize = configuration.MaxReceivedMessageSize;
+                            wsHttpBinding.MaxReceivedMessageSize = configuration.MaxReceivedMessageSize.GetValueOrDefault();
                         }
                         if (configuration.UseDefaultWebProxy != default)
                         {
-                            wsHttpBinding.UseDefaultWebProxy = configuration.UseDefaultWebProxy;
+                            wsHttpBinding.UseDefaultWebProxy = configuration.UseDefaultWebProxy.GetValueOrDefault();
                         }
                         if (configuration.BypassProxyOnLocal != default)
                         {
-                            wsHttpBinding.BypassProxyOnLocal = configuration.BypassProxyOnLocal;
+                            wsHttpBinding.BypassProxyOnLocal = configuration.BypassProxyOnLocal.GetValueOrDefault();
                         }
                         if (configuration.ProxyAddress != default)
                         {

--- a/src/Helsenorge.Registries/Configuration/WcfConfiguration.cs
+++ b/src/Helsenorge.Registries/Configuration/WcfConfiguration.cs
@@ -33,23 +33,23 @@ namespace Helsenorge.Registries.Configuration
         /// <summary>
         /// Gets or sets the maximum size, in bytes, for a buffer that receives messages from the channel.
         /// </summary>
-        public int MaxBufferSize { get; set; }
+        public int? MaxBufferSize { get; set; }
         /// <summary>
         /// Gets or sets the maximum amount of memory, in bytes, that is allocated for use by the manager of the message buffers that receive messages from the channel.
         /// </summary>
-        public int MaxBufferPoolSize { get; set; }
+        public int? MaxBufferPoolSize { get; set; }
         /// <summary>
         /// Gets or sets the maximum size, in bytes, for a message that can be received on a channel configured with this binding.
         /// </summary>
-        public int MaxReceivedMessageSize { get; set; }
+        public int? MaxReceivedMessageSize { get; set; }
         /// <summary>
         /// Gets or sets a value that indicates whether the auto-configured HTTP proxy of the system should be used, if available.
         /// </summary>
-        public bool UseDefaultWebProxy { get; set; }
+        public bool? UseDefaultWebProxy { get; set; }
         /// <summary>
         /// Gets or sets a value that indicates whether to bypass the proxy server for local addresses.
         /// </summary>
-        public bool BypassProxyOnLocal { get; set; }
+        public bool? BypassProxyOnLocal { get; set; }
         /// <summary>
         /// Gets or sets the URI address of the HTTP proxy.
         /// </summary>

--- a/test/Helsenorge.Registries.Tests/Configuration/ConfigurationChannelFactoryTests.cs
+++ b/test/Helsenorge.Registries.Tests/Configuration/ConfigurationChannelFactoryTests.cs
@@ -58,7 +58,38 @@ namespace Helsenorge.Registries.Tests.Configuration
             Assert.Null(factory.Credentials?.UserName.Password);
             Assert.Equal(default(Uri), binding.ProxyAddress);
             Assert.False(binding.BypassProxyOnLocal);
+            Assert.True(binding.UseDefaultWebProxy);
+            Assert.Equal(65536, binding.MaxBufferSize);
+            Assert.Equal(524288, binding.MaxBufferPoolSize);
+            Assert.Equal(65536, binding.MaxReceivedMessageSize);
+        }
+
+        [Fact]
+        public void Should_Create_Channel_Factory_With_Basic_Http_Binding_Configured()
+        {
+            var factory = new ConfigurationChannelFactory<ICommunicationPartyService>(new WcfConfiguration
+            {
+                UserName = "John",
+                Password = "Doe",
+                Address = "https://ws-web.test.nhn.no/v1/AR/Basic",
+                UseDefaultWebProxy = false,
+                BypassProxyOnLocal = true,
+                ProxyAddress = new Uri("http://proxy.helsenorge.utvikling:8080"),
+                MaxBufferSize = 1,
+                MaxBufferPoolSize = 2,
+                MaxReceivedMessageSize = 3
+            });
+            var binding = factory.Endpoint.Binding as BasicHttpBinding;
+            Assert.NotNull(binding);
+            Assert.Equal("John", factory.Credentials?.UserName.UserName);
+            Assert.Equal("Doe", factory.Credentials?.UserName.Password);
+            Assert.Equal("https://ws-web.test.nhn.no/v1/AR/Basic", factory.Endpoint.Address.Uri.OriginalString);
+            Assert.True(binding.BypassProxyOnLocal);
             Assert.False(binding.UseDefaultWebProxy);
+            Assert.Equal("http://proxy.helsenorge.utvikling:8080", binding.ProxyAddress.OriginalString);
+            Assert.Equal(1, binding.MaxBufferSize);
+            Assert.Equal(2, binding.MaxBufferPoolSize);
+            Assert.Equal(3, binding.MaxReceivedMessageSize);
         }
 
         [Fact]


### PR DESCRIPTION
Fixed issue where the setting UseDefaultWebProxy couldn't be set to
false. Fixed by making the property mapped from config nullable so you
can detect if it was set in config or not. Made this change to the other
properties to conform with this change.