### PR TITLE
Added XUnit VS runner to Registries.Tests project

### DIFF
--- a/test/Helsenorge.Registries.Tests/Helsenorge.Registries.Tests.csproj
+++ b/test/Helsenorge.Registries.Tests/Helsenorge.Registries.Tests.csproj
@@ -20,6 +20,10 @@
         <PackageReference Include="MSTest.TestFramework" Version="2.1.2" />
         <PackageReference Include="xunit" Version="2.4.1" />
         <PackageReference Include="xunit.assert" Version="2.4.1" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+          <PrivateAssets>all</PrivateAssets>
+          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="..\..\src\Helsenorge.Registries\Helsenorge.Registries.csproj" />


### PR DESCRIPTION
The XUnit fact tests were not running in Visual Studio for
Registries.Tests. This has been fixed by adding the
xunit.runner.visualstudio to the Helsenorge.Registries.Tests project