### PR TITLE
fix: FromHerId == 0 throw HeaderValidationException

### DIFF
--- a/src/Helsenorge.Messaging/ServiceBus/Receivers/MessageListener.cs
+++ b/src/Helsenorge.Messaging/ServiceBus/Receivers/MessageListener.cs
@@ -459,6 +459,10 @@ namespace Helsenorge.Messaging.ServiceBus.Receivers
             {
                 missingFields.Add(ServiceBusCore.ToHerIdHeaderKey);
             }
+            if(message.FromHerId == 0)
+            {
+                missingFields.Add(ServiceBusCore.FromHerIdHeaderKey);
+            }
             if (string.IsNullOrEmpty(message.MessageFunction))
             {
                 missingFields.Add("Label");

--- a/test/Helsenorge.Messaging.Tests/ServiceBus/Receivers/AsynchronousReceiveTests.cs
+++ b/test/Helsenorge.Messaging.Tests/ServiceBus/Receivers/AsynchronousReceiveTests.cs
@@ -202,11 +202,15 @@ namespace Helsenorge.Messaging.Tests.ServiceBus.Receivers
                 Assert.AreEqual(0, MockFactory.Helsenorge.Asynchronous.Messages.Count);
                 // we don't have enough information to know where to send it back
                 Assert.AreEqual(0, MockFactory.OtherParty.Error.Messages.Count);
+                var logEntries = MockLoggerProvider.Entries
+                .Where(entry => 
+                    entry.EventId == EventIds.MissingField && entry.Message.Contains("FromHerId is missing. No idea where to send the error")
+                );
+                Assert.AreEqual(1, logEntries.Count());
             },
-            wait: () => _receivedCalled,
+            wait: () => _handledExceptionCalled,
             received: (m) => 
             { 
-                Assert.AreEqual(CertificateErrors.Missing, m.SignatureError);
                 return Task.CompletedTask;
             },
             messageModification: (m) => { m.FromHerId = 0; });


### PR DESCRIPTION
* If FromHerId == 0 throw a HeaderValidationException from
  ValidateMessageHeader
* This changes the behavior somewhat and is reflected in the test
  Asynchronous_Receive_MissingFromHerId. We no longer get a
  CertificateErrors.Missing, but now receive a HeaderValidationException
  as explained above. This seems more in line with what actually is
  happening.
* Since we cannot send an AppRec or Error anywhere we abort during
  SendError and remove the message from queue