### PR TITLE
fix: Handle messages not being released properly

### DIFF
--- a/src/Helsenorge.Messaging/Abstractions/MessagingException.cs
+++ b/src/Helsenorge.Messaging/Abstractions/MessagingException.cs
@@ -119,6 +119,10 @@ namespace Helsenorge.Messaging.Abstractions
         /// The Messaging Entity Cache failed to close an entity.
         /// </summary>
         public static EventId MessagingEntityCacheFailedToCloseEntity = new EventId(36, EventIdName);
+        /// <summary>
+        /// Non-successful release of message.
+        /// </summary>
+        public static EventId MessageReleaseFailed = new EventId(37, EventIdName);
 
         /// <summary>
         /// Event Id used for informational purposes when starting/ending the Receive process.

--- a/src/Helsenorge.Messaging/ServiceBus/MessageReleaseThread.cs
+++ b/src/Helsenorge.Messaging/ServiceBus/MessageReleaseThread.cs
@@ -1,0 +1,61 @@
+﻿/* 
+ * Copyright (c) 2021, Norsk Helsenett SF and contributors
+ * See the file CONTRIBUTORS for details.
+ * 
+ * This file is licensed under the MIT license
+ * available at https://raw.githubusercontent.com/helsenorge/Helsenorge.Messaging/master/LICENSE
+ */
+
+using Helsenorge.Messaging.Abstractions;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Threading;
+
+namespace Helsenorge.Messaging.ServiceBus
+{
+    /// <summary>
+    /// The AwaitRelease method in this class is spun up on a thread and will
+    /// wait until we are close to Message.LockedUntil before we release the 
+    /// message. As soon as we release the message is immediately available on 
+    /// the queue.
+    /// </summary>
+    internal static class MessageReleaseThread
+    {
+        internal struct ThreadData
+        {
+            public IMessagingMessage Message;
+            public ILogger Logger;
+        }
+
+        internal static void AwaitRelease(object data)
+        {
+            if (!(data is ThreadData threadData)) return;
+
+            var message = threadData.Message;
+            var logger = threadData.Logger;
+            try
+            {
+                logger.LogInformation($"Start-MessageReleaseThread-AwaitRelease: MessageId: {message.MessageId} MessageFunction: {message.MessageFunction}");
+
+                var lockedUntil = message.LockedUntil;
+                var millisecondsBuffer = 300;
+                var millisecondsDelay = (int)lockedUntil.Subtract(DateTime.UtcNow).TotalMilliseconds - millisecondsBuffer;
+
+                logger.LogDebug($"MessageReleaseThread-AwaitRelease: MessageId: {message.MessageId}. Awaiting {millisecondsDelay} before releasing message.");
+
+                Thread.Sleep(millisecondsDelay);
+                message.Release();
+
+                logger.LogDebug($"MessageReleaseThread-AwaitRelease: MessageId: {message.MessageId}. Message has been released.");
+            }
+            catch (Exception ex)
+            {
+                logger.LogWarning(EventIds.MessageReleaseFailed, ex, $"MessageReleaseThread-AwaitRelease: {ex.Message}");
+            }
+            finally
+            {
+                logger.LogInformation($"End-MessageReleaseThread-AwaitRelease: MessageId: {message.MessageId} MessageFunction: {message.MessageFunction}");
+            }
+        }
+    }
+}


### PR DESCRIPTION
* When an unhandled exception occurs we do not release the message and
  we can therefore make our process hang for up to 10 minutes before it
  gets force detached by the broker. If we have several messages in the
  queue that end up with an unhandled exception we might end up in a
  longer delay where we can't process messages fast enough since our
  credits might be drained.
  Also we do not want to release the message that threw an unhandled
  exception since it will then become immediately available on the
  queue.
* This commit tries to fix this by spinning up a new thread which waits
  until we reach the message's LockedUntil and then releases it.