### PR TITLE
Ignore casing in communication process name from CPP service

### DIFF
--- a/src/Helsenorge.Registries/Abstractions/CollaborationProtocolProfile.cs
+++ b/src/Helsenorge.Registries/Abstractions/CollaborationProtocolProfile.cs
@@ -156,7 +156,7 @@ namespace Helsenorge.Registries.Abstractions
 
             if (messages == null)
             {
-                return Roles.SelectMany(role => role.SendMessages).FirstOrDefault((m) => m.Name.Equals(messageName, StringComparison.Ordinal));
+                return Roles.SelectMany(role => role.SendMessages).FirstOrDefault((m) => m.Name.Equals(messageName, StringComparison.OrdinalIgnoreCase));
             }
             else
             {
@@ -178,7 +178,7 @@ namespace Helsenorge.Registries.Abstractions
 
             if (messages == null)
             {
-                return Roles.SelectMany(role => role.ReceiveMessages).FirstOrDefault((m) => m.Name.Equals(messageName, StringComparison.Ordinal));
+                return Roles.SelectMany(role => role.ReceiveMessages).FirstOrDefault((m) => m.Name.Equals(messageName, StringComparison.OrdinalIgnoreCase));
             }
             else
             {

--- a/test/Helsenorge.Registries.Tests/CollaborationRegistryTests.cs
+++ b/test/Helsenorge.Registries.Tests/CollaborationRegistryTests.cs
@@ -218,6 +218,12 @@ namespace Helsenorge.Registries.Tests
             Assert.IsNotNull(profile.FindMessageForSender("APPREC"));
         }
         [TestMethod]
+        public void FindMessageForSender_Found_AppRec_IgnoreCase()
+        {
+            var profile = _registry.FindProtocolForCounterpartyAsync(_logger, 93238).Result;
+            Assert.IsNotNull(profile.FindMessageForSender("Apprec"));
+        }
+        [TestMethod]
         public void FindMessageForSender_Found_Ny_CPP()
         {
             var profile = _registry.FindProtocolForCounterpartyAsync(_logger, 93238).Result;


### PR DESCRIPTION
Ignore the casing in communication process name we receive from the CPP service.