### PR TITLE
refactor!: Add sync methods, rename async methods

### DIFF
--- a/src/Helsenorge.Messaging/Abstractions/IMessagingMessage.cs
+++ b/src/Helsenorge.Messaging/Abstractions/IMessagingMessage.cs
@@ -143,9 +143,13 @@ namespace Helsenorge.Messaging.Abstractions
         /// <param name="ex"></param>
         void AddDetailsToException(Exception ex);
         /// <summary>
-        /// Renews the peerlock of the message
+        /// Renews the lock of the message
         /// </summary>
         void RenewLock();
+        /// <summary>
+        /// Renews the lock of the message
+        /// </summary>
+        Task RenewLockAsync();
         /// <summary>
         /// Sends this message to the deadletter queue
         /// </summary>

--- a/src/Helsenorge.Messaging/Abstractions/IMessagingReceiver.cs
+++ b/src/Helsenorge.Messaging/Abstractions/IMessagingReceiver.cs
@@ -21,6 +21,12 @@ namespace Helsenorge.Messaging.Abstractions
         /// </summary>
         /// <param name="serverWaitTime">Timeout applied to receive operation</param>
         /// <returns></returns>
+        IMessagingMessage Receive(TimeSpan serverWaitTime);
+        /// <summary>
+        /// Receives a message
+        /// </summary>
+        /// <param name="serverWaitTime">Timeout applied to receive operation</param>
+        /// <returns></returns>
         Task<IMessagingMessage> ReceiveAsync(TimeSpan serverWaitTime);
     }
 }

--- a/src/Helsenorge.Messaging/Abstractions/IncomingMessage.cs
+++ b/src/Helsenorge.Messaging/Abstractions/IncomingMessage.cs
@@ -8,6 +8,7 @@
 
 using Helsenorge.Registries.Abstractions;
 using System;
+using System.Threading.Tasks;
 using System.Xml.Linq;
 
 namespace Helsenorge.Messaging.Abstractions
@@ -66,13 +67,36 @@ namespace Helsenorge.Messaging.Abstractions
         /// </summary>
         public bool ContentWasSigned { get; set; }
         /// <summary>
-        /// Renews the peerlock of the message
+        /// Renews the lock of the message
         /// </summary>
         public Action RenewLock { get; internal set; }
+        /// Renews the lock of the message
+        /// </summary>
+        public Func<Task> RenewLockAsync { get; internal set; }
         /// <summary>
         /// Removes the message from the queue.
         /// </summary>
         public Action Complete { get; internal set; }
+        /// <summary>
+        /// Removes the message from the queue.
+        /// </summary>
+        public Func<Task> CompleteAsync { get; internal set; }
+        /// <summary>
+        /// Releases the message.
+        /// </summary>
+        public Action Release { get; internal set; }
+        /// <summary>
+        /// Releases the message.
+        /// </summary>
+        public Func<Task> ReleaseAsync { get; internal set; }
+        /// <summary>
+        /// Deadletters the message.
+        /// </summary>
+        public Action Deadletter { get; internal set; }
+        /// <summary>
+        /// Deadletters the message.
+        /// </summary>
+        public Func<Task> DeadletterAsync { get; internal set; }
         /// <summary>
         /// Gets the number of deliveries.
         /// </summary>

--- a/src/Helsenorge.Messaging/ServiceBus/DefaultTimeManager.cs
+++ b/src/Helsenorge.Messaging/ServiceBus/DefaultTimeManager.cs
@@ -7,12 +7,18 @@
  */
 
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Helsenorge.Messaging.ServiceBus
 {
     internal class DefaultTimeManager : ITimeManager
     {
+        public void Delay(TimeSpan timeSpan)
+        {
+            Thread.Sleep(timeSpan);
+        }
+
         public async Task DelayAsync(TimeSpan timeSpan)
         {
             await Task.Delay(timeSpan).ConfigureAwait(false);

--- a/src/Helsenorge.Messaging/ServiceBus/ITimeManager.cs
+++ b/src/Helsenorge.Messaging/ServiceBus/ITimeManager.cs
@@ -13,6 +13,8 @@ namespace Helsenorge.Messaging.ServiceBus
 {
     internal interface ITimeManager
     {
+        void Delay(TimeSpan timeSpan);
+
         Task DelayAsync(TimeSpan timeSpan);
 
         DateTime CurrentTimeUtc { get; }

--- a/src/Helsenorge.Messaging/ServiceBus/Receivers/MessageListener.cs
+++ b/src/Helsenorge.Messaging/ServiceBus/Receivers/MessageListener.cs
@@ -168,7 +168,13 @@ namespace Helsenorge.Messaging.ServiceBus.Receivers
                     CorrelationId = message.CorrelationId,
                     EnqueuedTimeUtc = message.EnqueuedTimeUtc,
                     RenewLock = message.RenewLock,
+                    RenewLockAsync = message.RenewLockAsync,
                     Complete = message.Complete,
+                    CompleteAsync = message.CompleteAsync,
+                    Release = message.Release,
+                    ReleaseAsync = message.RelaseAsync,
+                    Deadletter = message.DeadLetter,
+                    DeadletterAsync = message.DeadLetterAsync,
                     DeliveryCount = message.DeliveryCount,
                     LockedUntil = message.LockedUntil,
                 };

--- a/src/Helsenorge.Messaging/ServiceBus/ServiceBusConnection.cs
+++ b/src/Helsenorge.Messaging/ServiceBus/ServiceBusConnection.cs
@@ -25,9 +25,15 @@ namespace Helsenorge.Messaging.ServiceBus
 
         public string Namespace { get; }
 
-        public async Task<IConnection> GetConnection()
+        public IConnection GetConnection()
         {
-            await EnsureConnection().ConfigureAwait(false);
+            EnsureConnection();
+            return _connection;
+        }
+
+        public async Task<IConnection> GetConnectionAsync()
+        {
+            await EnsureConnectionAsync().ConfigureAwait(false);
             return _connection;
         }
 
@@ -73,7 +79,25 @@ namespace Helsenorge.Messaging.ServiceBus
         /// Auto-reconnects until Close() is not called explicitly.
         /// </summary>
         /// <returns>Whether it's reconnected</returns>
-        public async Task<bool> EnsureConnection()
+        public bool EnsureConnection()
+        {
+            if (IsClosedOrClosing)
+            {
+                throw new ObjectDisposedException("Connection is closed");
+            }
+            if (_connection == null || _connection.IsClosed)
+            {
+                _connection = _connectionFactory.CreateAsync(_address).GetAwaiter().GetResult();
+                return true;
+            }
+            return false;
+        }
+
+        /// <summary>
+        /// Auto-reconnects until Close() is not called explicitly.
+        /// </summary>
+        /// <returns>Whether it's reconnected</returns>
+        public async Task<bool> EnsureConnectionAsync()
         {
             if (IsClosedOrClosing)
             {

--- a/src/Helsenorge.Messaging/ServiceBus/ServiceBusMessage.cs
+++ b/src/Helsenorge.Messaging/ServiceBus/ServiceBusMessage.cs
@@ -40,12 +40,18 @@ namespace Helsenorge.Messaging.ServiceBus
         public static readonly Symbol PartitionKeySymbol = new Symbol("x-opt-partition-key");
         public static readonly Symbol SequenceNumberSymbol = new Symbol("x-opt-sequence-number");
 
-        public Func<Task> CompleteAction { get; set; }
-        public Func<Task> RejectAction { get; set; }
-        public Func<Task> ReleaseAction { get; set; }
-        public Func<Task> DeadLetterAction { get; set; }
-        public Func<Task<DateTime>> RenewLockAction { get; set; }
-        public Func<bool, bool, Task> ModifyAction { get; set; }
+        public Action CompleteAction { get; set; }
+        public Func<Task> CompleteActionAsync { get; set; }
+        public Action RejectAction { get; set; }
+        public Func<Task> RejectActionAsync { get; set; }
+        public Action ReleaseAction { get; set; }
+        public Func<Task> ReleaseActionAsync { get; set; }
+        public Action DeadLetterAction { get; set; }
+        public Func<Task> DeadLetterActionAsync { get; set; }
+        public Func<DateTime> RenewLockAction { get; set; }
+        public Func<Task<DateTime>> RenewLockActionAsync { get; set; }
+        public Action<bool, bool> ModifyAction { get; set; }
+        public Func<bool, bool, Task> ModifyActionAsync { get; set; }
 
         public ServiceBusMessage(Message implementation)
         {
@@ -260,32 +266,39 @@ namespace Helsenorge.Messaging.ServiceBus
             return new ServiceBusMessage(clone)
             {
                 CompleteAction = CompleteAction,
+                CompleteActionAsync = CompleteActionAsync,
                 RejectAction = RejectAction,
+                RejectActionAsync = RejectActionAsync,
                 ReleaseAction = ReleaseAction,
+                ReleaseActionAsync = ReleaseActionAsync,
                 DeadLetterAction = DeadLetterAction,
-                RenewLockAction = RenewLockAction
+                DeadLetterActionAsync = DeadLetterActionAsync,
+                RenewLockAction = RenewLockAction,
+                RenewLockActionAsync = RenewLockActionAsync,
+                ModifyAction = ModifyAction,
+                ModifyActionAsync = ModifyActionAsync,
             };
         }
 
-        public void Complete() => CompleteAction.Invoke().GetAwaiter().GetResult();
+        public void Complete() => CompleteAction.Invoke();
 
-        public async Task CompleteAsync() => await CompleteAction.Invoke().ConfigureAwait(false);
+        public async Task CompleteAsync() => await CompleteActionAsync.Invoke().ConfigureAwait(false);
 
-        public void Reject() => ReleaseAction.Invoke().GetAwaiter().GetResult();
+        public void Reject() => ReleaseAction.Invoke();
 
-        public async Task RejectAsync() => await ReleaseAction.Invoke().ConfigureAwait(false);
+        public async Task RejectAsync() => await ReleaseActionAsync.Invoke().ConfigureAwait(false);
 
-        public void Release() => ReleaseAction.Invoke().GetAwaiter().GetResult();
+        public void Release() => ReleaseAction.Invoke();
 
-        public async Task RelaseAsync() =>  await ReleaseAction.Invoke().ConfigureAwait(false);
+        public async Task RelaseAsync() =>  await ReleaseActionAsync.Invoke().ConfigureAwait(false);
 
-        public void DeadLetter() => DeadLetterAction.Invoke().GetAwaiter().GetResult();
+        public void DeadLetter() => DeadLetterAction.Invoke();
 
-        public async Task DeadLetterAsync() => await DeadLetterAction.Invoke().ConfigureAwait(false);
+        public async Task DeadLetterAsync() => await DeadLetterActionAsync.Invoke().ConfigureAwait(false);
 
-        public void Modify(bool deliveryFailed, bool undeliverableHere = false) => ModifyAction.Invoke(deliveryFailed, undeliverableHere).GetAwaiter().GetResult();
+        public void Modify(bool deliveryFailed, bool undeliverableHere = false) => ModifyAction.Invoke(deliveryFailed, undeliverableHere);
 
-        public async Task ModifyAsync(bool deliveryFailed, bool undeliverableHere = false) => await ModifyAction.Invoke(deliveryFailed, undeliverableHere).ConfigureAwait(false);
+        public async Task ModifyAsync(bool deliveryFailed, bool undeliverableHere = false) => await ModifyActionAsync.Invoke(deliveryFailed, undeliverableHere).ConfigureAwait(false);
 
         [DebuggerStepThrough]
         public void Dispose() => _implementation.Dispose();
@@ -308,8 +321,13 @@ namespace Helsenorge.Messaging.ServiceBus
 
         public void RenewLock()
         {
-            var task = RenewLockAction.Invoke();
-            var lockedUntilUtc = task?.Result ?? DateTime.MinValue;
+            var lockedUntilUtc = RenewLockAction.Invoke();
+            _implementation.MessageAnnotations[LockedUntilSymbol] = lockedUntilUtc;
+        }
+
+        public async Task RenewLockAsync()
+        {
+            var lockedUntilUtc = await RenewLockActionAsync.Invoke().ConfigureAwait(false);
             _implementation.MessageAnnotations[LockedUntilSymbol] = lockedUntilUtc;
         }
 

--- a/src/Helsenorge.Messaging/ServiceBus/ServiceBusMessage.cs
+++ b/src/Helsenorge.Messaging/ServiceBus/ServiceBusMessage.cs
@@ -40,18 +40,18 @@ namespace Helsenorge.Messaging.ServiceBus
         public static readonly Symbol PartitionKeySymbol = new Symbol("x-opt-partition-key");
         public static readonly Symbol SequenceNumberSymbol = new Symbol("x-opt-sequence-number");
 
-        public Action CompleteAction { get; set; }
-        public Func<Task> CompleteActionAsync { get; set; }
-        public Action RejectAction { get; set; }
-        public Func<Task> RejectActionAsync { get; set; }
-        public Action ReleaseAction { get; set; }
-        public Func<Task> ReleaseActionAsync { get; set; }
-        public Action DeadLetterAction { get; set; }
-        public Func<Task> DeadLetterActionAsync { get; set; }
-        public Func<DateTime> RenewLockAction { get; set; }
-        public Func<Task<DateTime>> RenewLockActionAsync { get; set; }
-        public Action<bool, bool> ModifyAction { get; set; }
-        public Func<bool, bool, Task> ModifyActionAsync { get; set; }
+        internal Action CompleteAction { get; set; }
+        internal Func<Task> CompleteActionAsync { get; set; }
+        internal Action RejectAction { get; set; }
+        internal Func<Task> RejectActionAsync { get; set; }
+        internal Action ReleaseAction { get; set; }
+        internal Func<Task> ReleaseActionAsync { get; set; }
+        internal Action DeadLetterAction { get; set; }
+        internal Func<Task> DeadLetterActionAsync { get; set; }
+        internal Func<DateTime> RenewLockAction { get; set; }
+        internal Func<Task<DateTime>> RenewLockActionAsync { get; set; }
+        internal Action<bool, bool> ModifyAction { get; set; }
+        internal Func<bool, bool, Task> ModifyActionAsync { get; set; }
 
         public ServiceBusMessage(Message implementation)
         {

--- a/src/Helsenorge.Messaging/ServiceBus/ServiceBusOperationBuilder.cs
+++ b/src/Helsenorge.Messaging/ServiceBus/ServiceBusOperationBuilder.cs
@@ -47,13 +47,25 @@ namespace Helsenorge.Messaging.ServiceBus
             }
         }
 
-        public ServiceBusOperation<T> Build<T>(Func<Task<T>> func)
+        public ServiceBusAsyncOperation<T> Build<T>(Func<Task<T>> func)
+        {
+            Validate();
+            return new ServiceBusAsyncOperation<T>(this, func);
+        }
+
+        public ServiceBusAsyncOperation Build(Func<Task> func)
+        {
+            Validate();
+            return new ServiceBusAsyncOperation(this, func);
+        }
+
+        public ServiceBusOperation<T> Build<T>(Func<T> func)
         {
             Validate();
             return new ServiceBusOperation<T>(this, func);
         }
 
-        public ServiceBusOperation Build(Func<Task> func)
+        public ServiceBusOperation Build(Action func)
         {
             Validate();
             return new ServiceBusOperation(this, func);

--- a/src/Helsenorge.Messaging/ServiceBus/ServiceBusSender.cs
+++ b/src/Helsenorge.Messaging/ServiceBus/ServiceBusSender.cs
@@ -55,7 +55,7 @@ namespace Helsenorge.Messaging.ServiceBus
 
             await new ServiceBusOperationBuilder(_logger, "Send").Build(async () =>
             {
-                await EnsureOpen().ConfigureAwait(false);
+                await EnsureOpenAsync().ConfigureAwait(false);
                 await _link.SendAsync(originalMessage).ConfigureAwait(false);
             }).PerformAsync().ConfigureAwait(false);
         }

--- a/test/Helsenorge.Messaging.IntegrationTests/ServiceBus/ServiceBusConnectionTests.cs
+++ b/test/Helsenorge.Messaging.IntegrationTests/ServiceBus/ServiceBusConnectionTests.cs
@@ -31,7 +31,7 @@ namespace Helsenorge.Messaging.IntegrationTests.ServiceBus
         public async Task Should_Create_New_Connection_On_First_Access()
         {
             var connection = _fixture.Connection;
-            var conn = await connection.GetConnection();
+            var conn = await connection.GetConnectionAsync();
             Assert.False(conn.IsClosed);
             Assert.False(connection.IsClosedOrClosing);
             await connection.CloseAsync();
@@ -43,11 +43,11 @@ namespace Helsenorge.Messaging.IntegrationTests.ServiceBus
         public async Task Should_Not_Create_New_Connection_When_Underlying_Object_Is_Not_Closed()
         {
             var connection = _fixture.Connection;
-            var conn = await connection.GetConnection();
+            var conn = await connection.GetConnectionAsync();
             Assert.False(conn.IsClosed);
             Assert.False(connection.IsClosedOrClosing);
-            Assert.False(await connection.EnsureConnection());
-            var conn2 = await connection.GetConnection();
+            Assert.False(await connection.EnsureConnectionAsync());
+            var conn2 = await connection.GetConnectionAsync();
             Assert.Same(conn, conn2);
             Assert.False(conn.IsClosed);
         }
@@ -56,14 +56,14 @@ namespace Helsenorge.Messaging.IntegrationTests.ServiceBus
         public async Task Should_Create_New_Connection_When_Underlying_Object_Is_Closed()
         {
             var connection = _fixture.Connection;
-            var conn = await connection.GetConnection();
+            var conn = await connection.GetConnectionAsync();
             Assert.False(conn.IsClosed);
             Assert.False(connection.IsClosedOrClosing);
-            Assert.False(await connection.EnsureConnection());
+            Assert.False(await connection.EnsureConnectionAsync());
             conn.Close();
             Assert.True(conn.IsClosed);
             Assert.False(connection.IsClosedOrClosing);
-            var conn2 = await connection.GetConnection();
+            var conn2 = await connection.GetConnectionAsync();
             Assert.NotSame(conn, conn2);
             Assert.False(conn2.IsClosed);
         }
@@ -72,15 +72,15 @@ namespace Helsenorge.Messaging.IntegrationTests.ServiceBus
         public async Task Should_Not_Allow_To_Access_Connection_When_Closed()
         {
             var connection = _fixture.Connection;
-            var conn = await connection.GetConnection();
+            var conn = await connection.GetConnectionAsync();
             Assert.False(conn.IsClosed);
             Assert.False(connection.IsClosedOrClosing);
-            Assert.False(await connection.EnsureConnection());
+            Assert.False(await connection.EnsureConnectionAsync());
             await connection.CloseAsync();
             Assert.True(conn.IsClosed);
             Assert.True(connection.IsClosedOrClosing);
-            await Assert.ThrowsAsync<ObjectDisposedException>(async () => await connection.EnsureConnection());
-            await Assert.ThrowsAsync<ObjectDisposedException>(async () => await connection.GetConnection());
+            await Assert.ThrowsAsync<ObjectDisposedException>(async () => await connection.EnsureConnectionAsync());
+            await Assert.ThrowsAsync<ObjectDisposedException>(async () => await connection.GetConnectionAsync());
         }
 
         [Fact, Trait("Category", "IntegrationTest")]

--- a/test/Helsenorge.Messaging.IntegrationTests/ServiceBus/ServiceBusFixture.cs
+++ b/test/Helsenorge.Messaging.IntegrationTests/ServiceBus/ServiceBusFixture.cs
@@ -72,7 +72,7 @@ namespace Helsenorge.Messaging.IntegrationTests.ServiceBus
         {
             var list = new List<Message>();
             var connection = new ServiceBusConnection(GetConnectionString(), _logger);
-            var rawConnection = await connection.GetConnection();
+            var rawConnection = await connection.GetConnectionAsync();
             var session = rawConnection.CreateSession();
             var receiverLink = session.CreateReceiver($"test-receiver-link-{Guid.NewGuid()}", connection.GetEntityName(queueName));
             Message message;
@@ -96,7 +96,7 @@ namespace Helsenorge.Messaging.IntegrationTests.ServiceBus
                 messageText = $"Test message {Guid.NewGuid()}";
             }
             var connection = new ServiceBusConnection(GetConnectionString(), _logger);
-            var rawConnection = await connection.GetConnection();
+            var rawConnection = await connection.GetConnectionAsync();
             var session = rawConnection.CreateSession();
             var senderLink = session.CreateSender($"test-sender-link-{Guid.NewGuid()}", connection.GetEntityName(queueName));
             await senderLink.SendAsync(new Message
@@ -115,7 +115,7 @@ namespace Helsenorge.Messaging.IntegrationTests.ServiceBus
         public async Task CheckMessageSentAsync(string queueName, string text)
         {
             var connection = new ServiceBusConnection(GetConnectionString(), _logger);
-            var rawConnection = await connection.GetConnection();
+            var rawConnection = await connection.GetConnectionAsync();
             var session = rawConnection.CreateSession();
             var receiverLink = session.CreateReceiver($"test-receiver-link-{Guid.NewGuid()}", connection.GetEntityName(queueName));
             var message = await receiverLink.ReceiveAsync(ServiceBusTestingConstants.DefaultReadTimeout);

--- a/test/Helsenorge.Messaging.IntegrationTests/ServiceBus/ServiceBusMessageTests.cs
+++ b/test/Helsenorge.Messaging.IntegrationTests/ServiceBus/ServiceBusMessageTests.cs
@@ -141,7 +141,7 @@ namespace Helsenorge.Messaging.IntegrationTests.ServiceBus
             Assert.Equal(messageText, await message.GetBodyAsStingAsync());
             var wasLockedUntil = message.LockedUntil;
             await Task.Delay(TimeSpan.FromSeconds(1));
-            message.RenewLock();
+            await message.RenewLockAsync();
             Assert.True(message.LockedUntil > wasLockedUntil);
             Assert.True(message.LockedUntil - wasLockedUntil > TimeSpan.FromSeconds(1));
             await message.CompleteAsync();

--- a/test/Helsenorge.Messaging.IntegrationTests/ServiceBus/ServiceBusReceiverTests.cs
+++ b/test/Helsenorge.Messaging.IntegrationTests/ServiceBus/ServiceBusReceiverTests.cs
@@ -46,7 +46,7 @@ namespace Helsenorge.Messaging.IntegrationTests.ServiceBus
         public async Task Should_Recreate_Link_When_Underlying_Connection_Is_Closed()
         {
             Assert.False(_receiver.IsClosed);
-            var connection = await _fixture.Connection.GetConnection();
+            var connection = await _fixture.Connection.GetConnectionAsync();
             await connection.CloseAsync();
             await ReceiveTestMessageAsync();
             Assert.False(_receiver.IsClosed);

--- a/test/Helsenorge.Messaging.IntegrationTests/ServiceBus/ServiceBusSenderTests.cs
+++ b/test/Helsenorge.Messaging.IntegrationTests/ServiceBus/ServiceBusSenderTests.cs
@@ -49,7 +49,7 @@ namespace Helsenorge.Messaging.IntegrationTests.ServiceBus
         public async Task Should_Recreate_Link_When_Underlying_Connection_Is_Closed()
         {
             Assert.False(_sender.IsClosed);
-            var connection = await _fixture.Connection.GetConnection();
+            var connection = await _fixture.Connection.GetConnectionAsync();
             await connection.CloseAsync();
             await SendTestMessageAsync();
             Assert.False(_sender.IsClosed);

--- a/test/Helsenorge.Messaging.Tests/Mocks/MockMessage.cs
+++ b/test/Helsenorge.Messaging.Tests/Mocks/MockMessage.cs
@@ -155,7 +155,11 @@ namespace Helsenorge.Messaging.Tests.Mocks
 
         public void RenewLock()
         {
-            throw new NotImplementedException();
+        }
+
+        public Task RenewLockAsync()
+        {
+            return Task.CompletedTask;
         }
 
         public void Dispose()

--- a/test/Helsenorge.Messaging.Tests/Mocks/MockReceiver.cs
+++ b/test/Helsenorge.Messaging.Tests/Mocks/MockReceiver.cs
@@ -27,6 +27,20 @@ namespace Helsenorge.Messaging.Tests.Mocks
         public bool IsClosed => false;
         public Task Close() { return Task.CompletedTask; }
 
+        public IMessagingMessage Receive(TimeSpan serverWaitTime)
+        {
+            if (_factory.Qeueues.ContainsKey(_id))
+            {
+                var queue = _factory.Qeueues[_id];
+                if (queue.Count > 0)
+                {
+                    return queue.First();
+                }
+            }
+
+            return null;
+        }
+
         public async Task<IMessagingMessage> ReceiveAsync(TimeSpan serverWaitTime)
         {
             if (_factory.Qeueues.ContainsKey(_id))
@@ -37,7 +51,7 @@ namespace Helsenorge.Messaging.Tests.Mocks
                     return await Task.FromResult(queue.First());
                 }
             }
-            //System.Threading.Thread.Sleep(serverWaitTime);
+
             return null;
         }
     }

--- a/test/Helsenorge.Messaging.Tests/ServiceBus/Exceptions/ServiceBusOperationTests.cs
+++ b/test/Helsenorge.Messaging.Tests/ServiceBus/Exceptions/ServiceBusOperationTests.cs
@@ -110,6 +110,12 @@ namespace Helsenorge.Messaging.Tests.ServiceBus.Exceptions
         {
             public List<TimeSpan> Delays { get; } = new List<TimeSpan>();
 
+            public void Delay(TimeSpan timeSpan)
+            {
+                Delays.Add(timeSpan);
+                CurrentTimeUtc += timeSpan;
+            }
+
             public Task DelayAsync(TimeSpan timeSpan)
             {
                 Delays.Add(timeSpan);


### PR DESCRIPTION
refactor!: Add sync methods, rename async methods
BREAKING CHANGE: Add corresponding sync methods for async methods.
Rename async methods by suffixing them with Async.

refactor!: Make lambda expressions internal
BREAKING CHANGE: lambda expressions on ServiceBusMessage are now 
internal.