### PR TITLE
fix: ServiceBusOperation.Perform endless loop

### DIFF
--- a/src/Helsenorge.Messaging/ServiceBus/ServiceBusOperation.cs
+++ b/src/Helsenorge.Messaging/ServiceBus/ServiceBusOperation.cs
@@ -185,6 +185,7 @@ namespace Helsenorge.Messaging.ServiceBus
                 try
                 {
                     _func.Invoke();
+                    return;
                 }
                 catch (Exception e)
                 {


### PR DESCRIPTION
The ServiceBusOperation.Operation method did not return and ended up in
an endless loop.

Bug was introduced in 4.0.0-beta39