### PR TITLE
fix: Trim away any trailing slashes from the Namespace

### DIFF
--- a/src/Helsenorge.Messaging/ServiceBus/ServiceBusConnection.cs
+++ b/src/Helsenorge.Messaging/ServiceBus/ServiceBusConnection.cs
@@ -60,7 +60,7 @@ namespace Helsenorge.Messaging.ServiceBus
 
             if (!string.IsNullOrEmpty(_address.Path))
             {
-                Namespace = _address.Path.Substring(1);
+                Namespace = _address.Path.Substring(1).TrimEnd('/');
                 _address = new Address(connectionString.Substring(0, connectionString.Length - Namespace.Length));
             }
 


### PR DESCRIPTION
This fixes an issue where the Namespace can contain trailing slashes.
When we try to connect our Link to the ServiceBus/Broker it will get
confused and throw an error that it does not recognize the address.

This also seems to be related to a strange error we have had earlier
where the ServiceBus/Broker returns an obscure address- + message in
return telling us that we have tried to connect to that obscure address.

The obscure address + message is as follows: "The messaging entity
'sb://nhntestservicebus.servicebus.windows.net//8093563_async' could
not be found".