### PR TITLE
fix: Verify LockedUntil is not DateTime.MinValue

### DIFF
--- a/src/Helsenorge.Messaging/ServiceBus/Receivers/MessageListener.cs
+++ b/src/Helsenorge.Messaging/ServiceBus/Receivers/MessageListener.cs
@@ -153,7 +153,7 @@ namespace Helsenorge.Messaging.ServiceBus.Receivers
 
             try
             {
-                if(message.LockedUntil.ToUniversalTime() <= DateTime.UtcNow)
+                if(message.LockedUntil.ToUniversalTime() != DateTime.MinValue && message.LockedUntil.ToUniversalTime() <= DateTime.UtcNow)
                 {
                     Logger.LogInformation($"MessageListener::ReadAndProcessMessage - Ignoring message, lock expired at: {message.LockedUntil.ToUniversalTime()}");
                     return null;


### PR DESCRIPTION
This fixes an issue on some AMQP platforms/configurations where the
LockedUntil attribute is not set. Before checking if LockedUntil has
expired we need to verify if LockedUntil is not equal to
DateTime.MinValue.