### PR TITLE
fix: Check if KeyUsage is equal to KeyEncipherment not DataEncipherment

### DIFF
--- a/src/Helsenorge.Messaging/ServiceBus/Receivers/MessageListener.cs
+++ b/src/Helsenorge.Messaging/ServiceBus/Receivers/MessageListener.cs
@@ -345,7 +345,7 @@ namespace Helsenorge.Messaging.ServiceBus.Receivers
                 // validate the local encryption certificate and, if present, the local legacy encryption certificate 
                 incomingMessage.DecryptionError = validator == null
                     ? CertificateErrors.None
-                    : validator.Validate(Core.MessageProtection.EncryptionCertificate, X509KeyUsageFlags.DataEncipherment);
+                    : validator.Validate(Core.MessageProtection.EncryptionCertificate, X509KeyUsageFlags.KeyEncipherment);
                 // in earlier versions of Helsenorge.Messaging we removed the message, but we should rather 
                 // want it to be dead lettered since this is a temp issue that should be fixed locally.
                 ReportErrorOnLocalCertificate(originalMessage, Core.MessageProtection.EncryptionCertificate, incomingMessage.DecryptionError);
@@ -354,7 +354,7 @@ namespace Helsenorge.Messaging.ServiceBus.Receivers
                     // this is optional information that should only be in effect durin a short transition period
                     incomingMessage.LegacyDecryptionError = validator == null
                         ? CertificateErrors.None
-                        : validator.Validate(Core.MessageProtection.LegacyEncryptionCertificate, X509KeyUsageFlags.DataEncipherment);
+                        : validator.Validate(Core.MessageProtection.LegacyEncryptionCertificate, X509KeyUsageFlags.KeyEncipherment);
                     // if someone forgets to remove the legacy configuration, we log an error message but don't remove it
                     ReportErrorOnLocalCertificate(originalMessage, Core.MessageProtection.LegacyEncryptionCertificate, incomingMessage.LegacyDecryptionError);
                 }

--- a/src/Helsenorge.Messaging/ServiceBus/ServiceBusCore.cs
+++ b/src/Helsenorge.Messaging/ServiceBus/ServiceBusCore.cs
@@ -122,11 +122,11 @@ namespace Helsenorge.Messaging.ServiceBus
             {
                 var validator = Core.CertificateValidator;
                 // Validate external part's encryption certificate
-                logger.LogBeforeValidatingCertificate(outgoingMessage.MessageFunction, profile.EncryptionCertificate.Thumbprint, profile.EncryptionCertificate.Subject, "DataEncipherment", outgoingMessage.ToHerId, outgoingMessage.MessageId);
+                logger.LogBeforeValidatingCertificate(outgoingMessage.MessageFunction, profile.EncryptionCertificate.Thumbprint, profile.EncryptionCertificate.Subject, "KeyEncipherment", outgoingMessage.ToHerId, outgoingMessage.MessageId);
                 var encryptionStatus = validator == null
                     ? CertificateErrors.None
-                    : validator.Validate(profile.EncryptionCertificate, X509KeyUsageFlags.DataEncipherment);
-                logger.LogAfterValidatingCertificate(outgoingMessage.MessageFunction, profile.EncryptionCertificate.Thumbprint, profile.EncryptionCertificate.Subject, "DataEncipherment", outgoingMessage.ToHerId, outgoingMessage.MessageId);
+                    : validator.Validate(profile.EncryptionCertificate, X509KeyUsageFlags.KeyEncipherment);
+                logger.LogAfterValidatingCertificate(outgoingMessage.MessageFunction, profile.EncryptionCertificate.Thumbprint, profile.EncryptionCertificate.Subject, "KeyEncipherment", outgoingMessage.ToHerId, outgoingMessage.MessageId);
 
                 logger.LogBeforeValidatingCertificate(outgoingMessage.MessageFunction, Core.MessageProtection.SigningCertificate.Thumbprint, Core.MessageProtection.SigningCertificate.Subject, "NonRepudiation", Core.Settings.MyHerId, outgoingMessage.MessageId);
                 // Validate "our" own signature certificate

--- a/src/Helsenorge.Registries/CollaborationProtocolRegistry.cs
+++ b/src/Helsenorge.Registries/CollaborationProtocolRegistry.cs
@@ -87,7 +87,7 @@ namespace Helsenorge.Registries
             if (result != null)
             {
                 var errors = CertificateErrors.None; 
-                errors |= CertificateValidator.Validate(result.EncryptionCertificate, X509KeyUsageFlags.DataEncipherment);
+                errors |= CertificateValidator.Validate(result.EncryptionCertificate, X509KeyUsageFlags.KeyEncipherment);
                 errors |= CertificateValidator.Validate(result.SignatureCertificate, X509KeyUsageFlags.NonRepudiation);
                 // if the certificates are valid, only then do we return a value from the cache
                 if (errors == CertificateErrors.None)
@@ -166,7 +166,7 @@ namespace Helsenorge.Registries
             if (result != null)
             {
                 var errors = CertificateErrors.None;
-                errors |= CertificateValidator.Validate(result.EncryptionCertificate, X509KeyUsageFlags.DataEncipherment);
+                errors |= CertificateValidator.Validate(result.EncryptionCertificate, X509KeyUsageFlags.KeyEncipherment);
                 errors |= CertificateValidator.Validate(result.SignatureCertificate, X509KeyUsageFlags.NonRepudiation);
                 // if the certificates are valid, only then do we return a value from the cache
                 if (errors == CertificateErrors.None)
@@ -242,7 +242,7 @@ namespace Helsenorge.Registries
             if (result != null)
             {
                 var errors = CertificateErrors.None;
-                errors |= CertificateValidator.Validate(result.EncryptionCertificate, X509KeyUsageFlags.DataEncipherment);
+                errors |= CertificateValidator.Validate(result.EncryptionCertificate, X509KeyUsageFlags.KeyEncipherment);
                 errors |= CertificateValidator.Validate(result.SignatureCertificate, X509KeyUsageFlags.NonRepudiation);
                 // if the certificates are valid, only then do we return a value from the cache
                 if (errors == CertificateErrors.None)

--- a/test/Helsenorge.Messaging.Tests/ServiceBus/Receivers/AsynchronousReceiveTests.cs
+++ b/test/Helsenorge.Messaging.Tests/ServiceBus/Receivers/AsynchronousReceiveTests.cs
@@ -312,7 +312,7 @@ namespace Helsenorge.Messaging.Tests.ServiceBus.Receivers
         public async Task Asynchronous_Receive_LocalCertificateStartDate()
         {
             CertificateValidator.SetError(
-                (c, u) => (u == X509KeyUsageFlags.DataEncipherment) ? CertificateErrors.StartDate : CertificateErrors.None);
+                (c, u) => (u == X509KeyUsageFlags.KeyEncipherment) ? CertificateErrors.StartDate : CertificateErrors.None);
 
             await RunAsynchronousReceive(
                postValidation: () =>
@@ -333,7 +333,7 @@ namespace Helsenorge.Messaging.Tests.ServiceBus.Receivers
         public async Task Asynchronous_Receive_LocalCertificateEndDate()
         {
             CertificateValidator.SetError(
-                (c, u) => (u == X509KeyUsageFlags.DataEncipherment) ? CertificateErrors.EndDate : CertificateErrors.None);
+                (c, u) => (u == X509KeyUsageFlags.KeyEncipherment) ? CertificateErrors.EndDate : CertificateErrors.None);
 
             await RunAsynchronousReceive(
                postValidation: () =>
@@ -354,7 +354,7 @@ namespace Helsenorge.Messaging.Tests.ServiceBus.Receivers
         public async Task Asynchronous_Receive_LocalCertificateUsage()
         {
             CertificateValidator.SetError(
-                (c, u) => (u == X509KeyUsageFlags.DataEncipherment) ? CertificateErrors.Usage : CertificateErrors.None);
+                (c, u) => (u == X509KeyUsageFlags.KeyEncipherment) ? CertificateErrors.Usage : CertificateErrors.None);
 
             await RunAsynchronousReceive(
                postValidation: () =>
@@ -375,7 +375,7 @@ namespace Helsenorge.Messaging.Tests.ServiceBus.Receivers
         public async Task Asynchronous_Receive_LocalCertificateRevoked()
         {
             CertificateValidator.SetError(
-                (c, u) => (u == X509KeyUsageFlags.DataEncipherment) ? CertificateErrors.Revoked : CertificateErrors.None);
+                (c, u) => (u == X509KeyUsageFlags.KeyEncipherment) ? CertificateErrors.Revoked : CertificateErrors.None);
 
             await RunAsynchronousReceive(
                postValidation: () =>
@@ -396,7 +396,7 @@ namespace Helsenorge.Messaging.Tests.ServiceBus.Receivers
         public async Task Asynchronous_Receive_LocalCertificateRevokedUnknown()
         {
             CertificateValidator.SetError(
-                (c, u) => (u == X509KeyUsageFlags.DataEncipherment) ? CertificateErrors.RevokedUnknown : CertificateErrors.None);
+                (c, u) => (u == X509KeyUsageFlags.KeyEncipherment) ? CertificateErrors.RevokedUnknown : CertificateErrors.None);
 
             await RunAsynchronousReceive(
                postValidation: () =>
@@ -418,7 +418,7 @@ namespace Helsenorge.Messaging.Tests.ServiceBus.Receivers
         {
             CertificateValidator.SetError(
                 (c, u) =>
-                    (u == X509KeyUsageFlags.DataEncipherment)
+                    (u == X509KeyUsageFlags.KeyEncipherment)
                         ? CertificateErrors.StartDate | CertificateErrors.EndDate
                         : CertificateErrors.None);
 

--- a/test/Helsenorge.Messaging.Tests/ServiceBus/Senders/AsynchronousSendTests.cs
+++ b/test/Helsenorge.Messaging.Tests/ServiceBus/Senders/AsynchronousSendTests.cs
@@ -118,7 +118,7 @@ namespace Helsenorge.Messaging.Tests.ServiceBus.Senders
         public void Send_Asynchronous_InvalidEncryption()
         {
             Settings.IgnoreCertificateErrorOnSend = false;
-            CertificateValidator.SetError((c,u)=> (u == X509KeyUsageFlags.DataEncipherment) ? CertificateErrors.StartDate : CertificateErrors.None);
+            CertificateValidator.SetError((c,u)=> (u == X509KeyUsageFlags.KeyEncipherment) ? CertificateErrors.StartDate : CertificateErrors.None);
 
             var message = CreateMessage();
             RunAndHandleMessagingException(Client.SendAndContinueAsync(message), EventIds.RemoteCertificate);
@@ -127,7 +127,7 @@ namespace Helsenorge.Messaging.Tests.ServiceBus.Senders
         public void Send_Asynchronous_InvalidEncryption_Ignore()
         {
             Settings.IgnoreCertificateErrorOnSend = true;
-            CertificateValidator.SetError((c, u) => (u == X509KeyUsageFlags.DataEncipherment) ? CertificateErrors.StartDate : CertificateErrors.None);
+            CertificateValidator.SetError((c, u) => (u == X509KeyUsageFlags.KeyEncipherment) ? CertificateErrors.StartDate : CertificateErrors.None);
 
             var message = CreateMessage();
             RunAndHandleException(Client.SendAndContinueAsync(message));

--- a/test/Helsenorge.Registries.Tests/CertificateValidatorTests.cs
+++ b/test/Helsenorge.Registries.Tests/CertificateValidatorTests.cs
@@ -55,7 +55,7 @@ namespace Helsenorge.Registries.Tests
         {
             var validator = new CertificateValidator();
             var error = validator.Validate(TestCertificates.CounterpartyPublicSignature,
-                X509KeyUsageFlags.DataEncipherment);
+                X509KeyUsageFlags.KeyEncipherment);
             Assert.AreEqual(CertificateErrors.Usage, error);
         }
         [TestMethod]
@@ -71,7 +71,7 @@ namespace Helsenorge.Registries.Tests
         //{
         //	var validator = new CertificateValidator();
         //	var error = validator.Validate(TestCertificates.HelsenorgePublicEncryptionInvalid,
-        //		X509KeyUsageFlags.DataEncipherment);
+        //		X509KeyUsageFlags.KeyEncipherment);
         //	Assert.AreEqual(CertificateErrors.StartDate | CertificateErrors.Usage, error);
         //}
 


### PR DESCRIPTION
This fixes changes in certificates related to the SEID2 changes.
The new certificates will no longer contain the KeyUsage flag
DataEncipherment, so instead we check for the flag KeyEncipherment.