### PR TITLE
Configuration: TimeToLive default for Error Queue determined by Broker

### DIFF
--- a/src/Helsenorge.Messaging/MessagingSettings.cs
+++ b/src/Helsenorge.Messaging/MessagingSettings.cs
@@ -245,7 +245,7 @@ namespace Helsenorge.Messaging
         /// <summary>
         /// Time to live for messages sent
         /// </summary>
-        public TimeSpan TimeToLive { get; set; } = TimeSpan.MaxValue;
+        public TimeSpan TimeToLive { get; set; } = TimeSpan.Zero;
         /// <summary>
         /// Timeout for read operations
         /// </summary>
@@ -256,7 +256,6 @@ namespace Helsenorge.Messaging
         internal void Validate()
         {
             if (ProcessingTasks <= 0) throw new ArgumentOutOfRangeException(nameof(ProcessingTasks));
-            if (TimeToLive == TimeSpan.Zero) throw new ArgumentOutOfRangeException(nameof(TimeToLive));
             if (ReadTimeout == TimeSpan.Zero) throw new ArgumentOutOfRangeException(nameof(ReadTimeout));
         }
     }

--- a/test/Helsenorge.Messaging.Tests/OptionTests.cs
+++ b/test/Helsenorge.Messaging.Tests/OptionTests.cs
@@ -159,13 +159,6 @@ namespace Helsenorge.Messaging.Tests
         }
         [TestMethod]
         [ExpectedException(typeof(ArgumentOutOfRangeException))]
-        public void Error_TimeToLive_NotSet()
-        {
-            Settings.ServiceBus.Error.TimeToLive = TimeSpan.Zero;
-            Client = new MessagingClient(Settings, LoggerFactory, CollaborationRegistry, AddressRegistry, CertificateStore);
-        }
-        [TestMethod]
-        [ExpectedException(typeof(ArgumentOutOfRangeException))]
         public void Error_ReadTimeout_NotSet()
         {
             Settings.ServiceBus.Error.ReadTimeout = TimeSpan.Zero;


### PR DESCRIPTION
This sets the default for ErrorSettings.TimeToLive to zero. This allows
the broker to use a centralized value for how long a message is allowed
to live on error queue.