### PR TITLE
MessagingEntityCache: Introduce cache criterias for better recycling

### DIFF
--- a/src/Helsenorge.Messaging/MessagingSettings.cs
+++ b/src/Helsenorge.Messaging/MessagingSettings.cs
@@ -80,7 +80,9 @@ namespace Helsenorge.Messaging
     {
         internal const int DefaultMaxLinksPerSession = 64;
         internal const ushort DefaultMaxSessions = 256;
-        internal const int DefaultLinkCredits = 25;
+        private const int DefaultLinkCredits = 25;
+        private const ushort DefaultCacheEntryTimeToLive = 120;
+        private const ushort DefaultMaxCacheEntryTrimCount = 24;
 
         private readonly MessagingSettings _settings;
 
@@ -124,6 +126,14 @@ namespace Helsenorge.Messaging
         /// Get or set the link-credit being used by the receiver link. Setting this overrides the default value of 1 credit.
         /// </summary>
         public int LinkCredits { get; set; } = DefaultLinkCredits;
+        /// <summary>
+        /// The time in seconds since the last time a cache entry was used and when we consider it prime for recycling.
+        /// </summary>
+        public ushort CacheEntryTimeToLive { get; set; } = DefaultCacheEntryTimeToLive;
+        /// <summary>
+        /// The max cache entries our recycling process will handle each time it is triggered.
+        /// </summary>
+        public ushort MaxCacheEntryTrimCount { get; set; } = DefaultMaxCacheEntryTrimCount;
 
         /// <summary>
         /// The Her id that we represent

--- a/src/Helsenorge.Messaging/ServiceBus/ServiceBusFactoryPool.cs
+++ b/src/Helsenorge.Messaging/ServiceBus/ServiceBusFactoryPool.cs
@@ -23,7 +23,7 @@ namespace Helsenorge.Messaging.ServiceBus
         private IMessagingFactory _alternateMessagingFactor;
 
         public ServiceBusFactoryPool(ServiceBusSettings settings) :
-            base("FactoryPool", settings.MaxFactories)
+            base("FactoryPool", settings.MaxFactories, settings.CacheEntryTimeToLive, settings.MaxCacheEntryTrimCount)
         {
             _settings = settings;
         }

--- a/src/Helsenorge.Messaging/ServiceBus/ServiceBusReceiverPool.cs
+++ b/src/Helsenorge.Messaging/ServiceBus/ServiceBusReceiverPool.cs
@@ -18,7 +18,7 @@ namespace Helsenorge.Messaging.ServiceBus
         private readonly int _credit;
         
         public ServiceBusReceiverPool(ServiceBusSettings settings, IServiceBusFactoryPool factoryPool) :
-            base("ReceiverPool", settings.MaxReceivers)
+            base("ReceiverPool", settings.MaxReceivers, settings.CacheEntryTimeToLive, settings.MaxCacheEntryTrimCount)
         {
             _factoryPool = factoryPool;
             _credit = settings.LinkCredits;

--- a/src/Helsenorge.Messaging/ServiceBus/ServiceBusSenderPool.cs
+++ b/src/Helsenorge.Messaging/ServiceBus/ServiceBusSenderPool.cs
@@ -17,7 +17,7 @@ namespace Helsenorge.Messaging.ServiceBus
         private readonly IServiceBusFactoryPool _factoryPool;
         
         public ServiceBusSenderPool(ServiceBusSettings settings,  IServiceBusFactoryPool factoryPool) :
-            base("SenderPool", settings.MaxSenders)
+            base("SenderPool", settings.MaxSenders, settings.CacheEntryTimeToLive, settings.MaxCacheEntryTrimCount)
         {
             _factoryPool = factoryPool;
         }


### PR DESCRIPTION
This enhances the cache by introducing several criterias for when an
entity can be recycled.

CacheEntry<T>.ClosePending is removed and we now rely on
CacheEntry<T>.ActiveCount and CacheEntry<T>.LastUsed for when an entry
is prime for recycling.

The selection process for recycling is as following:
1. MessagingEntityCache<T>.Entries > Capacity
2. Select Min(MessagingEntityCache<T>.Entries - Capacity, MaxTrimCount)
3. CacheEntry<T>.Entity.IsClosed == false
  and (CacheEntry<T>.LastUsed < Now - CacheTimeToLive)
  and CacheEntry<T>.ActiveCount == 0

Functional description:
1. Start recycle only if we have exceeded Capacity
2. Select min value of either
   MessagingEntityCache<T>.Entries - Capacity
   or MaxTrimCount
3. Entity should not be closed
   and Last Time the entry was Used should be less than
    [current_time] - CacheTimeToLive
   and Entity should have ActiveCount equal to 0 (zero)

The following settings have been added to ServiceBusSettings:
- CacheEntryTimeToLive (Default value 120 seconds)
  This determines how long an entry will live in the cache before it is
  considered prime for removal
- MaxCacheEntryTrimCount (Default value 24)
  This is max count of entries we will recycle each time TrimEntries is
  triggered