### PR TITLE
ServiceBusFactoryPool: Do not increment ActiveCount beyond 1

### DIFF
--- a/src/Helsenorge.Messaging/Abstractions/MessagingEntityCache.cs
+++ b/src/Helsenorge.Messaging/Abstractions/MessagingEntityCache.cs
@@ -56,6 +56,10 @@ namespace Helsenorge.Messaging.Abstractions
         private readonly ushort _maxTrimCountPerRecycle;
         private bool _shutdownPending;
         /// <summary>
+        /// Set to false to not increment <see cref="CacheEntry{TE}.ActiveCount"/>
+        /// </summary>
+        protected bool _incrementActiveCount = true;
+        /// <summary>
         /// Gets the maximum number of items the cache can hold
         /// </summary>
         public uint Capacity { get; }
@@ -129,7 +133,8 @@ namespace Helsenorge.Messaging.Abstractions
 
                 entry = _entries[path];
 
-                entry.ActiveCount++;
+                if(_incrementActiveCount)
+                    entry.ActiveCount++;
                 entry.LastUsed = DateTime.Now;
                 logger.LogInformation(EventIds.MessagingEntityCacheProcessor, $"MessagingEntityCache::Create: Updating entry for {path} ActiveCount={entry.ActiveCount}");
 

--- a/src/Helsenorge.Messaging/ServiceBus/ServiceBusFactoryPool.cs
+++ b/src/Helsenorge.Messaging/ServiceBus/ServiceBusFactoryPool.cs
@@ -55,9 +55,14 @@ namespace Helsenorge.Messaging.ServiceBus
                 if (_index == Capacity)
                 {
                     _index = 0;
+                    // Make sure we do not increment ActiveCount any further after we have created all the needed
+                    // ServiceBusFactory instances.
+                    if(_incrementActiveCount) _incrementActiveCount = false;
                 }
                 var name = string.Format(null, "MessagingFactory{0}", _index);
-                return await Create(logger, name).ConfigureAwait(false);
+                var factory = await Create(logger, name).ConfigureAwait(false);
+
+                return factory;
             }
             finally
             {


### PR DESCRIPTION
The ServiceBusFactoryPool issues ServiceBusFactories which contains the
actual AMQP Connection which should not be recycled unless we shut down
or are disconnected because of network issues.

Because of this Release will never be called for a ServiceBusFactory and
ActiveCount would just be incremented forever until restart.

This commit let's us override this by setting the member variable
_incrementActiveCount of MessagingEntityCache<T> to false after creation
of the necessary ServiceBusFactories. With this change ActiveCount for a
ServiceBusFactory will never exceed ActiveCount of 1.