### PR TITLE
Verify authentication credentials

### DIFF
--- a/Documentation/Feilkoder.md
+++ b/Documentation/Feilkoder.md
@@ -88,6 +88,12 @@ The Messaging Entity Cache failed to close an entity.
 ### MUG-000037
 Non-successful release of message.
 
+### MUG-000038
+Non-sucessful authentication or connection attempt to one ore more of the web services on start-up.
+
+### MUG-000039
+Non-sucessful authentication or connection attempt to the message broker.
+
 ### MUG-001001
 Informasjonsformål når mottaksprosessen starter/avslutter
 

--- a/Documentation/Feilkoder.md
+++ b/Documentation/Feilkoder.md
@@ -82,6 +82,12 @@ Feil som avsender har rapportert. Ting som kommer inn på error køen.
 ### MUG-000035
 Ukjent feil har oppstått.
 
+### MUG-000036
+The Messaging Entity Cache failed to close an entity.
+
+### MUG-000037
+Non-successful release of message.
+
 ### MUG-001001
 Informasjonsformål når mottaksprosessen starter/avslutter
 

--- a/src/Helsenorge.Messaging/Abstractions/MessagingException.cs
+++ b/src/Helsenorge.Messaging/Abstractions/MessagingException.cs
@@ -123,6 +123,14 @@ namespace Helsenorge.Messaging.Abstractions
         /// Non-successful release of message.
         /// </summary>
         public static EventId MessageReleaseFailed = new EventId(37, EventIdName);
+        /// <summary>
+        /// Non-sucessful authentication or connection attempt to one ore more of the web services on start-up.
+        /// </summary>
+        public static EventId ConnectionToWebServiceFailed = new EventId(38, EventIdName);
+        /// <summary>
+        /// Non-sucessful authentication or connection attempt to the message broker.
+        /// </summary>
+        public static EventId ConnectionToMessageBrokerFailed = new EventId(39, EventIdName);
 
         /// <summary>
         /// Event Id used for informational purposes when starting/ending the Receive process.

--- a/src/Helsenorge.Messaging/MessagingServer.cs
+++ b/src/Helsenorge.Messaging/MessagingServer.cs
@@ -23,7 +23,7 @@ namespace Helsenorge.Messaging
     /// Default implementation for <see cref="IMessagingServer"/>
     /// This must be hosted as a singleton in order to leverage connection pooling against the message bus
     /// </summary>
-    public sealed class MessagingServer : MessagingCore, IMessagingServer, IMessagingNotification
+    public class MessagingServer : MessagingCore, IMessagingServer, IMessagingNotification
     {
         private readonly ILogger _logger;
         private readonly ILoggerFactory _loggerFactory;
@@ -477,7 +477,7 @@ namespace Helsenorge.Messaging
             }
         }
 
-        internal async Task<bool> CanAuthenticateAndPingAddressRegistryService()
+        internal virtual async Task<bool> CanAuthenticateAndPingAddressRegistryService()
         {
             try
             {
@@ -493,7 +493,7 @@ namespace Helsenorge.Messaging
             return true;
         }
 
-        internal async Task<bool> CanAuthenticateAndPingCppaService()
+        internal virtual async Task<bool> CanAuthenticateAndPingCppaService()
         {
             try
             {
@@ -511,7 +511,7 @@ namespace Helsenorge.Messaging
             return true;
         }
 
-        internal async Task<bool> CanAuthenticateAgainstMessageBroker()
+        internal virtual async Task<bool> CanAuthenticateAgainstMessageBroker()
         {
             ServiceBusConnection connection = null;
             try

--- a/src/Helsenorge.Registries/Abstractions/IAddressRegistry.cs
+++ b/src/Helsenorge.Registries/Abstractions/IAddressRegistry.cs
@@ -66,5 +66,11 @@ namespace Helsenorge.Registries.Abstractions
         /// <param name="forceUpdate">Set to true to force cache update.</param>
         /// <returns></returns>
         Task<CertificateDetails> GetCertificateDetailsForValidatingSignatureAsync(ILogger logger, int herId, bool forceUpdate);
+
+        /// <summary>
+        /// Tries to Ping the AddressRegistry Service to verify a connection.
+        /// </summary>
+        /// <param name="logger">An ILogger object that will be used for logging.</param>
+        Task PingAsync(ILogger logger);
     }
 }

--- a/src/Helsenorge.Registries/Abstractions/ICollaborationProtocolRegistry.cs
+++ b/src/Helsenorge.Registries/Abstractions/ICollaborationProtocolRegistry.cs
@@ -58,5 +58,12 @@ namespace Helsenorge.Registries.Abstractions
         /// <param name="forceUpdate">Set to true to force cache update.</param>
         /// <returns></returns>
         Task<CollaborationProtocolProfile> FindAgreementForCounterpartyAsync(ILogger logger, int counterpartyHerId, bool forceUpdate);
+
+        /// <summary>
+        /// Tries to Ping the AddressRegistry Service to verify a connection.
+        /// </summary>
+        /// <param name="logger">An ILogger object that will be used for logging.</param>
+        [Obsolete("This metod will be replaced in the future.")]
+        Task PingAsync(ILogger logger, int herId);
     }
 }

--- a/src/Helsenorge.Registries/AddressRegistry.cs
+++ b/src/Helsenorge.Registries/AddressRegistry.cs
@@ -169,7 +169,11 @@ namespace Helsenorge.Registries
             }
             return certificateDetails == null ? default(Abstractions.CertificateDetails) : MapCertificateDetails(herId, certificateDetails);
         }
-        
+
+        /// <inheritdoc cref="IAddressRegistry.PingAsync"/>
+        public Task PingAsync(ILogger logger)
+            => PingAsyncInternal(logger);
+
         /// <summary>
         /// Makes the actual call to the registry. This is virtual so that it can be mocked by unit tests
         /// </summary>
@@ -199,6 +203,12 @@ namespace Helsenorge.Registries
         [ExcludeFromCodeCoverage]
         internal virtual Task<AddressService.CertificateDetails> GetCertificateDetailsForValidatingSignatureInternal(ILogger logger, int herId)
             => Invoke(logger, x => x.GetCertificateDetailsForValidatingSignatureAsync(herId), "GetCertificateDetailsForValidatingSignatureAsync");
+
+        /// <inheritdoc cref="PingAsync"/>
+        /// <remarks>Makes the acutal call to the registry. It's a virtual method to make it mockable for unit tests.</remarks>
+        [ExcludeFromCodeCoverage]
+        internal virtual Task PingAsyncInternal(ILogger logger)
+            => Invoke(logger, x => x.PingAsync(), "PingAsync");
 
         private static CommunicationPartyDetails MapCommunicationPartyDetails(CommunicationParty communicationParty)
         {

--- a/src/Helsenorge.Registries/CollaborationProtocolRegistry.cs
+++ b/src/Helsenorge.Registries/CollaborationProtocolRegistry.cs
@@ -278,6 +278,19 @@ namespace Helsenorge.Registries
             await CacheExtensions.WriteValueToCache(logger, _cache, key, result, _settings.CachingInterval).ConfigureAwait(false);
             return result;
         }
+
+        /// <inheritdoc cref="PingAsync"/>
+        [Obsolete("This metod will be replaced in the future.")]
+        public async Task PingAsync(ILogger logger, int herId)
+        {
+            await PingAsyncInternal(logger, herId).ConfigureAwait(false);
+        }
+
+        [ExcludeFromCodeCoverage]
+        protected virtual async Task PingAsyncInternal(ILogger logger, int herId)
+        {
+            _ = await Invoke(logger, service => service.GetCppForCommunicationPartyAsync(herId), "GetCppForCommunicationPartyAsync").ConfigureAwait(false);
+        }
         
         private CollaborationProtocolProfile CreateDummyCollaborationProtocolProfile(int herId, Abstractions.CertificateDetails encryptionCertificate, Abstractions.CertificateDetails signatureCertificate)
         {

--- a/src/Helsenorge.Registries/Mocks/AddressRegistryMock.cs
+++ b/src/Helsenorge.Registries/Mocks/AddressRegistryMock.cs
@@ -91,5 +91,10 @@ namespace Helsenorge.Registries.Mocks
             }
             return await Task.FromResult(Utils.Deserialize<CertificateDetails>(xml)).ConfigureAwait(false);
         }
+
+        internal override Task PingAsyncInternal(ILogger logger)
+        {
+            return Task.CompletedTask;
+        }
     }
 }

--- a/src/Helsenorge.Registries/Mocks/CollaborationProtocolRegistryMock.cs
+++ b/src/Helsenorge.Registries/Mocks/CollaborationProtocolRegistryMock.cs
@@ -121,5 +121,10 @@ namespace Helsenorge.Registries.Mocks
             };
             return Task.FromResult(details);
         }
+
+        protected override Task PingAsyncInternal(ILogger logger, int herId)
+        {
+            return Task.CompletedTask;
+        }
     }
 }

--- a/test/Helsenorge.Messaging.Tests/BaseTest.cs
+++ b/test/Helsenorge.Messaging.Tests/BaseTest.cs
@@ -35,7 +35,7 @@ namespace Helsenorge.Messaging.Tests
         internal ILogger Logger { get; private set; }
 
         protected MessagingClient Client { get; set; }
-        protected MessagingServer Server { get; set; }
+        protected MockMessagingServer Server { get; set; }
         protected MessagingSettings Settings { get; set; }
         internal MockFactory MockFactory { get; set; }
 
@@ -165,7 +165,7 @@ namespace Helsenorge.Messaging.Tests
             ); ;
             Client.ServiceBus.RegisterAlternateMessagingFactory(MockFactory);
 
-            Server = new MessagingServer(
+            Server = new MockMessagingServer(
                 Settings, 
                 LoggerFactory, 
                 CollaborationRegistry, 

--- a/test/Helsenorge.Messaging.Tests/Mocks/MockMessagingServer.cs
+++ b/test/Helsenorge.Messaging.Tests/Mocks/MockMessagingServer.cs
@@ -1,0 +1,35 @@
+﻿using System.Threading.Tasks;
+using Helsenorge.Messaging.Abstractions;
+using Helsenorge.Registries.Abstractions;
+using Microsoft.Extensions.Logging;
+
+namespace Helsenorge.Messaging.Tests.Mocks
+{
+    /// <inheritdoc />
+    public class MockMessagingServer : MessagingServer
+    {
+        /// <inheritdoc />
+        public MockMessagingServer(MessagingSettings settings, ILoggerFactory loggerFactory, ICollaborationProtocolRegistry collaborationProtocolRegistry, IAddressRegistry addressRegistry)
+            : base(settings, loggerFactory, collaborationProtocolRegistry, addressRegistry)
+        {
+        }
+
+        /// <inheritdoc />
+        public MockMessagingServer(MessagingSettings settings, ILoggerFactory loggerFactory, ICollaborationProtocolRegistry collaborationProtocolRegistry, IAddressRegistry addressRegistry, ICertificateStore certificateStore)
+            : base(settings, loggerFactory, collaborationProtocolRegistry, addressRegistry, certificateStore)
+        {
+        }
+
+        /// <inheritdoc />
+        public MockMessagingServer(MessagingSettings settings, ILoggerFactory loggerFactory, ICollaborationProtocolRegistry collaborationProtocolRegistry, IAddressRegistry addressRegistry, ICertificateStore certificateStore, ICertificateValidator certificateValidator, IMessageProtection messageProtection)
+            : base(settings, loggerFactory, collaborationProtocolRegistry, addressRegistry, certificateStore, certificateValidator, messageProtection)
+        {
+        }
+
+        /// <inheritdoc />
+        internal override Task<bool> CanAuthenticateAgainstMessageBroker()
+        {
+            return Task.FromResult(true);
+        }
+    }
+}

--- a/test/Helsenorge.Messaging.Tests/ServiceBus/Receivers/AsynchronousReceiveTests.cs
+++ b/test/Helsenorge.Messaging.Tests/ServiceBus/Receivers/AsynchronousReceiveTests.cs
@@ -81,7 +81,7 @@ namespace Helsenorge.Messaging.Tests.ServiceBus.Receivers
             Client.ServiceBus.RegisterAlternateMessagingFactory(MockFactory);
 
             var partyBProtection = new SignThenEncryptMessageProtection(TestCertificates.HelsenorgePrivateSigntature, TestCertificates.HelsenorgePrivateEncryption);
-            Server = new MessagingServer(Settings, LoggerFactory, CollaborationRegistry, AddressRegistry, CertificateStore, CertificateValidator, partyBProtection);
+            Server = new MockMessagingServer(Settings, LoggerFactory, CollaborationRegistry, AddressRegistry, CertificateStore, CertificateValidator, partyBProtection);
             Server.ServiceBus.RegisterAlternateMessagingFactory(MockFactory);
 
             CollaborationRegistry.SetupFindAgreementForCounterparty(i =>


### PR DESCRIPTION
Registries: Add PingAsync to Registry interfaces 
* This patch adds a PingAsync methods for the interfaces IAddressRegistry and ICollaborationProtocolRegistry.
* The ICollaborationProtocolRegistry.PingAsync method is currently a hack since that Web Service does not yet expose a Ping method.

MessagingException: Add two new Event Ids
- Added Event Ids:
  - 38 - ConnectionToWebServiceFailed
  - 39 - ConnectionToMessageBrokerFailed

MessagingServer: Verify our authentication credentials
- Before we start the Receive loop in the MessagingServer verify that we can authenticate against the external services using our credentials.

MessagingServer: Make MessagingServer mockable and add Mock
- We need to be able to mock out methods on MessagingServer. Therefore we
have removed the sealed keyword from MessagingServer. Also added
MockMessagingServer so that our tests pass.

Documentation: Add Error Codes 38 and 39
- Add Error Code 38: ConnectionToWebServiceFailed
- Add Error Code 39: ConnectionToMessageBrokerFailed

Fixes #289
Fixes #110 