### PR TITLE
New Linkfactory class and examples of how to use it

### DIFF
--- a/Examples/SimpleReceiver/Program.cs
+++ b/Examples/SimpleReceiver/Program.cs
@@ -1,0 +1,76 @@
+﻿/*
+ * Copyright (c) 2021, Norsk Helsenett SF and contributors
+ * See the file CONTRIBUTORS for details.
+ *
+ * This file is licensed under the MIT license
+ * available at https://raw.githubusercontent.com/helsenorge/Helsenorge.Messaging/master/LICENSE
+ */
+
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using Helsenorge.Messaging.Abstractions;
+using Helsenorge.Messaging.ServiceBus;
+using Microsoft.Extensions.Logging;
+
+namespace SimpleReceiver
+{
+    class Program
+    {
+        private static readonly string _connectionString = "amqp://guest:guest@127.0.0.1:5672";
+        private static readonly string _queue = "/amq/queue/kenneth-test-queue";
+
+        static async Task Main(string[] args)
+        {
+            var loggerFactory = new LoggerFactory();
+            var connection = new ServiceBusConnection(_connectionString, loggerFactory.CreateLogger<ServiceBusConnection>());
+            IMessagingReceiver receiver = null;
+            try
+            {
+                var linkFactory = new LinkFactory(connection, loggerFactory.CreateLogger<LinkFactory>());
+                receiver = linkFactory.CreateReceiver(_queue, 200);
+                int i = 0;
+                while (true)
+                {
+                    var message = await receiver.ReceiveAsync(TimeSpan.FromSeconds(5));
+                    if (message == null) break;
+
+                    Console.WriteLine($"Message Id: {message.MessageId}");
+
+                    var stream = message.GetBody();
+                    if (stream != null)
+                    {
+                        var outputStream = new StreamReader(stream);
+                        var body = outputStream.ReadToEnd();
+
+                        Console.WriteLine($"Message Body: {body}");
+                    }
+
+                    Console.WriteLine($"Messages received: {i++}");
+
+                    await message.CompleteAsync();
+                }
+
+                await receiver.Close().ConfigureAwait(false);
+                await connection.CloseAsync();
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine($"An error occurred: '{e.Message}'.\nStack Trace: {e.StackTrace}");
+            }
+            finally
+            {
+                if (receiver != null)
+                    await receiver.Close();
+
+                if (connection != null)
+                    await connection.CloseAsync();
+            }
+
+            Console.WriteLine("Press any key to continue. . .");
+            Console.ReadKey(true);
+        }
+    }    
+}
+
+

--- a/Examples/SimpleReceiver/SimpleReceiver.csproj
+++ b/Examples/SimpleReceiver/SimpleReceiver.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <LangVersion>8.0</LangVersion>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\..\src\Helsenorge.Messaging\Helsenorge.Messaging.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/Examples/SimpleSender/Program.cs
+++ b/Examples/SimpleSender/Program.cs
@@ -1,0 +1,71 @@
+﻿/*
+ * Copyright (c) 2021, Norsk Helsenett SF and contributors
+ * See the file CONTRIBUTORS for details.
+ *
+ * This file is licensed under the MIT license
+ * available at https://raw.githubusercontent.com/helsenorge/Helsenorge.Messaging/master/LICENSE
+ */
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+using Helsenorge.Messaging.Abstractions;
+using Helsenorge.Messaging.ServiceBus;
+using Microsoft.Extensions.Logging;
+
+namespace SimpleSender
+{
+    class Program
+    {
+        // amqps should always be used in production and usually it will be used in the test environments.
+        //private static readonly string _connectionString = "amqps://[username]:[password]@127.0.0.1:5671";
+
+        // amqp can be used in your local test environment.
+        private static readonly string _connectionString = "amqp://[username]:[password]@127.0.0.1:5672";
+        private static readonly string _queue = "/amq/queue/test-queue";
+
+        static async Task Main(string[] args)
+        {
+            var loggerFactory = new LoggerFactory();
+            var connection = new ServiceBusConnection(_connectionString, loggerFactory.CreateLogger<ServiceBusConnection>());
+            IMessagingSender sender = null;
+            var messageCount = 20000;
+            try
+            {
+                var linkFactory = new LinkFactory(connection, loggerFactory.CreateLogger<LinkFactory>());
+                sender = linkFactory.CreateSender(_queue);
+                for (int i = 0; i < messageCount; i++)
+                {
+                    var outgoingMessage = new OutgoingMessage
+                    {
+                        MessageId = Guid.NewGuid().ToString("N")
+                    };
+                    var bodyString = $"Hello world! - {i + 1}";
+                    var body = new MemoryStream(Encoding.UTF8.GetBytes(bodyString));
+
+                    var message = await linkFactory.CreateMessageAsync(123, outgoingMessage, body);
+
+                    await sender.SendAsync(message);
+
+                    Console.WriteLine($"Message Id: '{message.MessageId}'\nMessage Body: '{bodyString}'\nMessages sent: '{i + 1}'.");
+                }
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine($"An error occurred: '{e.Message}'.\nStack Trace: {e.StackTrace}");
+            }
+            finally
+            {
+                if(sender != null)
+                    await sender.Close();
+                if (connection != null)
+                    await connection.CloseAsync();
+            }
+
+            Console.WriteLine("Press any key to continue. . .");
+            Console.ReadKey(true);
+        }
+    }
+}

--- a/Examples/SimpleSender/SimpleSender.csproj
+++ b/Examples/SimpleSender/SimpleSender.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <LangVersion>8.0</LangVersion>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.8" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\..\src\Helsenorge.Messaging\Helsenorge.Messaging.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/Messaging.sln
+++ b/Messaging.sln
@@ -58,6 +58,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Examples", "Examples", "{05
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SimpleSender", "Examples\SimpleSender\SimpleSender.csproj", "{D86E01D4-983C-4F30-A69D-8C80A927D16E}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SimpleReceiver", "Examples\SimpleReceiver\SimpleReceiver.csproj", "{413014B4-E40D-4D41-8068-8509995F3814}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -96,6 +98,10 @@ Global
 		{D86E01D4-983C-4F30-A69D-8C80A927D16E}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D86E01D4-983C-4F30-A69D-8C80A927D16E}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D86E01D4-983C-4F30-A69D-8C80A927D16E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{413014B4-E40D-4D41-8068-8509995F3814}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{413014B4-E40D-4D41-8068-8509995F3814}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{413014B4-E40D-4D41-8068-8509995F3814}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{413014B4-E40D-4D41-8068-8509995F3814}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -106,6 +112,7 @@ Global
 		{5D87F89A-6AF1-438B-B483-F5B5D8778C85} = {C78E1F1C-6AE6-4E64-8211-90EEC7A5FCAD}
 		{D65E8495-DAAD-46D6-8053-8D911A5C24F3} = {C78E1F1C-6AE6-4E64-8211-90EEC7A5FCAD}
 		{D86E01D4-983C-4F30-A69D-8C80A927D16E} = {0539614B-FB26-4204-B08C-D044A8DEAA41}
+		{413014B4-E40D-4D41-8068-8509995F3814} = {0539614B-FB26-4204-B08C-D044A8DEAA41}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {925B24E8-92AC-4D8D-959E-64DE4928A23B}

--- a/Messaging.sln
+++ b/Messaging.sln
@@ -51,7 +51,12 @@ ProjectSection(SolutionItems) = preProject
 	Documentation\SendeMeldinger.md = Documentation\SendeMeldinger.md
 	Documentation\Testmiljøer.md = Documentation\Testmiljøer.md
 	Documentation\Eksempler.md = Documentation\Eksempler.md
+	Documentation\MigrateFrom3To4.md = Documentation\MigrateFrom3To4.md
 EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Examples", "Examples", "{0539614B-FB26-4204-B08C-D044A8DEAA41}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SimpleSender", "Examples\SimpleSender\SimpleSender.csproj", "{D86E01D4-983C-4F30-A69D-8C80A927D16E}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -87,6 +92,10 @@ Global
 		{EEF50149-F300-4C09-BB26-5C75CF8AB88B}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{EEF50149-F300-4C09-BB26-5C75CF8AB88B}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{EEF50149-F300-4C09-BB26-5C75CF8AB88B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D86E01D4-983C-4F30-A69D-8C80A927D16E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D86E01D4-983C-4F30-A69D-8C80A927D16E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D86E01D4-983C-4F30-A69D-8C80A927D16E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D86E01D4-983C-4F30-A69D-8C80A927D16E}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -96,6 +105,7 @@ Global
 		{FB9DDD90-D5A5-4F25-8C81-4E6C9B4A18EE} = {E5E73A1E-1589-4B95-A894-B27029F5707C}
 		{5D87F89A-6AF1-438B-B483-F5B5D8778C85} = {C78E1F1C-6AE6-4E64-8211-90EEC7A5FCAD}
 		{D65E8495-DAAD-46D6-8053-8D911A5C24F3} = {C78E1F1C-6AE6-4E64-8211-90EEC7A5FCAD}
+		{D86E01D4-983C-4F30-A69D-8C80A927D16E} = {0539614B-FB26-4204-B08C-D044A8DEAA41}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {925B24E8-92AC-4D8D-959E-64DE4928A23B}

--- a/src/Helsenorge.Messaging/ServiceBus/LinkFactory.cs
+++ b/src/Helsenorge.Messaging/ServiceBus/LinkFactory.cs
@@ -1,0 +1,61 @@
+﻿/*
+ * Copyright (c) 2021, Norsk Helsenett SF and contributors
+ * See the file CONTRIBUTORS for details.
+ *
+ * This file is licensed under the MIT license
+ * available at https://raw.githubusercontent.com/helsenorge/Helsenorge.Messaging/master/LICENSE
+ */
+
+using System.IO;
+using System.Threading.Tasks;
+using Amqp;
+using Amqp.Framing;
+using Helsenorge.Messaging.Abstractions;
+using Microsoft.Extensions.Logging;
+
+namespace Helsenorge.Messaging.ServiceBus
+{
+    public class LinkFactory
+    {
+        private readonly ServiceBusConnection _connection;
+        private readonly ILogger<LinkFactory> _logger;
+
+        public LinkFactory(ServiceBusConnection connection, ILogger<LinkFactory> logger)
+        {
+            _connection = connection;
+            _logger = logger;
+        }
+
+        public IMessagingReceiver CreateReceiver(string queue, int linkCredit = 25)
+            => new ServiceBusReceiver(_connection, queue, linkCredit, _logger);
+
+        public IMessagingSender CreateSender(string queue)
+            => new ServiceBusSender(_connection, queue, _logger);
+
+        public async Task<IMessagingMessage> CreateMessageAsync(int fromHerId, OutgoingMessage message, Stream payload)
+        {
+            using var payloadMemoryStream = new MemoryStream();
+            await payload.CopyToAsync(payloadMemoryStream);
+
+            var innerMessage = new Message
+            {
+                BodySection = new Data
+                {
+                    Binary = payloadMemoryStream.ToArray(),
+                }
+            };
+
+            return new ServiceBusMessage(innerMessage)
+            {
+                MessageId = message.MessageId,
+                MessageFunction = string.IsNullOrWhiteSpace(message.ReceiptForMessageFunction)
+                    ? message.MessageFunction
+                    : message.ReceiptForMessageFunction,
+                ToHerId = message.ToHerId,
+                FromHerId = fromHerId,
+                ScheduledEnqueueTimeUtc = message.ScheduledSendTimeUtc,
+
+            };
+        }
+    }
+}

--- a/src/Helsenorge.Messaging/ServiceBus/ServiceBusConnection.cs
+++ b/src/Helsenorge.Messaging/ServiceBus/ServiceBusConnection.cs
@@ -13,13 +13,13 @@ using Microsoft.Extensions.Logging;
 
 namespace Helsenorge.Messaging.ServiceBus
 {
-    internal class ServiceBusConnection
+    public class ServiceBusConnection
     {
         private ConnectionFactory _connectionFactory;
         private readonly Address _address;
-        
 
-        public ServiceBusHttpClient HttpClient { get; }
+
+        internal ServiceBusHttpClient HttpClient { get; }
 
         private IConnection _connection;
 


### PR DESCRIPTION
ServiceBus: Add LinkFactory and publicly expose ServiceBusConnection
- This exposes the class ServiceBusConnection publicly and adds a LinkFactory.
- The LinkFactory exposes a set of methods to which can be used to create Senders and Receivers. It also exposes a method which helps to create an outgoing message.

Examples: A simple example for sending messages 
- This example shows how to use the new LinkFactory when sending messages.

Examples: A simple example for receiving messages 
- This example shows how to use the new LinkFactory when receiving messages.