### PR TITLE
ServiceBus+Tests: Add support for RabbitMQ Routing+Addressing

### DIFF
--- a/Examples/PooledReceiver/Program.cs
+++ b/Examples/PooledReceiver/Program.cs
@@ -17,8 +17,8 @@ namespace PooledReceiver
 {
     class Program
     {
-        private static readonly string _connectionString = "amqp://guest:guest@127.0.0.1:5672";
-        private static readonly string _queue = "/amq/queue/test-queue";
+        private static readonly string _connectionString = "amqp://guest:guest@127.0.0.1:5672/NHNTESTServiceBus";
+        private static readonly string _queue = "test-queue";
 
         static async Task Main(string[] args)
         {
@@ -26,6 +26,7 @@ namespace PooledReceiver
             var settings = new ServiceBusSettings
             {
                 ConnectionString = _connectionString,
+                MessageBrokerDialect = MessageBrokerDialect.RabbitMQ,
             };
 
             await using var linkFactoryPool = new LinkFactoryPool(settings, loggerFactory.CreateLogger<LinkFactoryPool>());

--- a/Examples/PooledSender/Program.cs
+++ b/Examples/PooledSender/Program.cs
@@ -19,8 +19,8 @@ namespace PooledSender
 {
     class Program
     {
-        private static readonly string _connectionString = "amqp://guest:guest@127.0.0.1:5672";
-        private static readonly string _queue = "/amq/queue/test-queue";
+        private static readonly string _connectionString = "amqp://guest:guest@127.0.0.1:5672/NHNTESTServiceBus";
+        private static readonly string _queue = "test-queue";
 
         static async Task Main(string[] args)
         {
@@ -28,6 +28,7 @@ namespace PooledSender
             var settings = new ServiceBusSettings
             {
                 ConnectionString = _connectionString,
+                MessageBrokerDialect = MessageBrokerDialect.RabbitMQ,
             };
 
             await using var linkFactoryPool = new LinkFactoryPool(settings, loggerFactory.CreateLogger<LinkFactoryPool>());

--- a/src/Helsenorge.Messaging/MessagingSettings.cs
+++ b/src/Helsenorge.Messaging/MessagingSettings.cs
@@ -1,5 +1,5 @@
 /* 
- * Copyright (c) 2020, Norsk Helsenett SF and contributors
+ * Copyright (c) 2020-2021, Norsk Helsenett SF and contributors
  * See the file CONTRIBUTORS for details.
  * 
  * This file is licensed under the MIT license
@@ -10,6 +10,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Security.Cryptography.X509Certificates;
+using Helsenorge.Messaging.ServiceBus;
 
 namespace Helsenorge.Messaging
 {
@@ -98,6 +99,11 @@ namespace Helsenorge.Messaging
         {
             _settings = settings;
         }
+
+        /// <summary>
+        /// Gets or set the Type of Message Broker we are using
+        /// </summary>
+        public MessageBrokerDialect MessageBrokerDialect { get; set; } = MessageBrokerDialect.ServiceBus;
 
         /// <summary>
         /// Gets or sets the connection string

--- a/src/Helsenorge.Messaging/ServiceBus/LinkRole.cs
+++ b/src/Helsenorge.Messaging/ServiceBus/LinkRole.cs
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2021, Norsk Helsenett SF and contributors
+ * See the file CONTRIBUTORS for details.
+ *
+ * This file is licensed under the MIT license
+ * available at https://raw.githubusercontent.com/helsenorge/Helsenorge.Messaging/master/LICENSE
+ */
+
+namespace Helsenorge.Messaging.ServiceBus
+{
+    /// <summary>Indicates the the role of the AMQP link.</summary>
+    internal enum LinkRole
+    {
+        /// <summary>The link has the sender role.</summary>
+        Sender = 1,
+        /// <summary>The link has the receiver role.</summary>
+        Receiver = 2,
+    }
+}

--- a/src/Helsenorge.Messaging/ServiceBus/MessageBrokerDialect.cs
+++ b/src/Helsenorge.Messaging/ServiceBus/MessageBrokerDialect.cs
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2021, Norsk Helsenett SF and contributors
+ * See the file CONTRIBUTORS for details.
+ *
+ * This file is licensed under the MIT license
+ * available at https://raw.githubusercontent.com/helsenorge/Helsenorge.Messaging/master/LICENSE
+ */
+
+namespace Helsenorge.Messaging.ServiceBus
+{
+    /// <summary>The kind of Message Broker Dialect.</summary>
+    public enum MessageBrokerDialect
+    {
+        /// <summary>The Message Broker Dialect is MS ServiceBus</summary>
+        ServiceBus = 1,
+        /// <summary>The Message Broker Dialect is RabbitMQ</summary>
+        RabbitMQ = 2,
+    }
+}

--- a/src/Helsenorge.Messaging/ServiceBus/ServiceBusFactoryPool.cs
+++ b/src/Helsenorge.Messaging/ServiceBus/ServiceBusFactoryPool.cs
@@ -1,5 +1,5 @@
 ﻿/* 
- * Copyright (c) 2020, Norsk Helsenett SF and contributors
+ * Copyright (c) 2020-2021, Norsk Helsenett SF and contributors
  * See the file CONTRIBUTORS for details.
  * 
  * This file is licensed under the MIT license
@@ -37,7 +37,7 @@ namespace Helsenorge.Messaging.ServiceBus
         protected override Task<IMessagingFactory> CreateEntity(ILogger logger, string id)
         {
             if (_alternateMessagingFactor != null) return Task.FromResult(_alternateMessagingFactor);
-            var connection = new ServiceBusConnection(_settings.ConnectionString, _settings.MaxLinksPerSession, _settings.MaxSessionsPerConnection, logger);
+            var connection = new ServiceBusConnection(_settings.ConnectionString, _settings.MessageBrokerDialect, _settings.MaxLinksPerSession, _settings.MaxSessionsPerConnection, logger);
             return Task.FromResult<IMessagingFactory>(new ServiceBusFactory(connection, logger));
         }
         public async Task<IMessagingMessage> CreateMessage(ILogger logger, Stream stream)

--- a/src/Helsenorge.Messaging/ServiceBus/ServiceBusReceiver.cs
+++ b/src/Helsenorge.Messaging/ServiceBus/ServiceBusReceiver.cs
@@ -1,5 +1,5 @@
 ﻿/* 
- * Copyright (c) 2020, Norsk Helsenett SF and contributors
+ * Copyright (c) 2020-2021, Norsk Helsenett SF and contributors
  * See the file CONTRIBUTORS for details.
  * 
  * This file is licensed under the MIT license
@@ -40,7 +40,7 @@ namespace Helsenorge.Messaging.ServiceBus
 
         protected override ReceiverLink CreateLink(ISession session)
         {
-            var receiver = session.CreateReceiver(Name, Connection.GetEntityName(_id)) as ReceiverLink;
+            var receiver = session.CreateReceiver(Name, Connection.GetEntityName(_id, LinkRole.Receiver)) as ReceiverLink;
             receiver.SetCredit(_credit);
             return receiver;
         }

--- a/src/Helsenorge.Messaging/ServiceBus/ServiceBusSender.cs
+++ b/src/Helsenorge.Messaging/ServiceBus/ServiceBusSender.cs
@@ -1,5 +1,5 @@
 ﻿/* 
- * Copyright (c) 2020, Norsk Helsenett SF and contributors
+ * Copyright (c) 2020-2021, Norsk Helsenett SF and contributors
  * See the file CONTRIBUTORS for details.
  * 
  * This file is licensed under the MIT license
@@ -38,7 +38,7 @@ namespace Helsenorge.Messaging.ServiceBus
 
         protected override SenderLink CreateLink(ISession session)
         {
-            return session.CreateSender(Name, Connection.GetEntityName(_id)) as SenderLink;
+            return session.CreateSender(Name, Connection.GetEntityName(_id, LinkRole.Sender)) as SenderLink;
         }
 
         public void Send(IMessagingMessage message)

--- a/test/Helsenorge.Messaging.IntegrationTests/ServiceBus/ServiceBusFixture.cs
+++ b/test/Helsenorge.Messaging.IntegrationTests/ServiceBus/ServiceBusFixture.cs
@@ -1,5 +1,5 @@
 ﻿/* 
- * Copyright (c) 2020, Norsk Helsenett SF and contributors
+ * Copyright (c) 2020-2021, Norsk Helsenett SF and contributors
  * See the file CONTRIBUTORS for details.
  * 
  * This file is licensed under the MIT license
@@ -74,7 +74,7 @@ namespace Helsenorge.Messaging.IntegrationTests.ServiceBus
             var connection = new ServiceBusConnection(GetConnectionString(), _logger);
             var rawConnection = await connection.GetInternalConnectionAsync();
             var session = rawConnection.CreateSession();
-            var receiverLink = session.CreateReceiver($"test-receiver-link-{Guid.NewGuid()}", connection.GetEntityName(queueName));
+            var receiverLink = session.CreateReceiver($"test-receiver-link-{Guid.NewGuid()}", connection.GetEntityName(queueName, LinkRole.Receiver));
             Message message;
             while ((message = await receiverLink.ReceiveAsync(ServiceBusTestingConstants.DefaultReadTimeout)) != null)
             {
@@ -98,7 +98,7 @@ namespace Helsenorge.Messaging.IntegrationTests.ServiceBus
             var connection = new ServiceBusConnection(GetConnectionString(), _logger);
             var rawConnection = await connection.GetInternalConnectionAsync();
             var session = rawConnection.CreateSession();
-            var senderLink = session.CreateSender($"test-sender-link-{Guid.NewGuid()}", connection.GetEntityName(queueName));
+            var senderLink = session.CreateSender($"test-sender-link-{Guid.NewGuid()}", connection.GetEntityName(queueName, LinkRole.Sender));
             await senderLink.SendAsync(new Message
             {
                 BodySection = new Data
@@ -117,7 +117,7 @@ namespace Helsenorge.Messaging.IntegrationTests.ServiceBus
             var connection = new ServiceBusConnection(GetConnectionString(), _logger);
             var rawConnection = await connection.GetInternalConnectionAsync();
             var session = rawConnection.CreateSession();
-            var receiverLink = session.CreateReceiver($"test-receiver-link-{Guid.NewGuid()}", connection.GetEntityName(queueName));
+            var receiverLink = session.CreateReceiver($"test-receiver-link-{Guid.NewGuid()}", connection.GetEntityName(queueName, LinkRole.Receiver));
             var message = await receiverLink.ReceiveAsync(ServiceBusTestingConstants.DefaultReadTimeout);
             Assert.NotNull(message);
             receiverLink.Accept(message);

--- a/test/Helsenorge.Messaging.Tests/ServiceBus/ServiceBusConnectionTests.cs
+++ b/test/Helsenorge.Messaging.Tests/ServiceBus/ServiceBusConnectionTests.cs
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2021, Norsk Helsenett SF and contributors
+ * See the file CONTRIBUTORS for details.
+ *
+ * This file is licensed under the MIT license
+ * available at https://raw.githubusercontent.com/helsenorge/Helsenorge.Messaging/master/LICENSE
+ */
+
+using Helsenorge.Messaging.ServiceBus;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Helsenorge.Messaging.Tests.ServiceBus
+{
+    [TestClass]
+    public class ServiceBusConnectionTests
+    {
+        private static string ConnectionString = "amqps://guest:guest@messagebroker.nhn.no/NameSpaceTest";
+
+        [TestMethod]
+        public void CanGetEnityNameForReceiverLinkForRabbitMQ()
+        {
+            var serviceBusConnection = new ServiceBusConnection(ConnectionString, MessageBrokerDialect.RabbitMQ, new Logger<ServiceBusConnectionTests>(new NullLoggerFactory()));
+            var entityName = serviceBusConnection.GetEntityName("my-queue-name", LinkRole.Receiver);
+            Assert.AreEqual("/amq/queue/my-queue-name", entityName);
+        }
+
+        [TestMethod]
+        public void CanGetEnityNameForSenderLinkForRabbitMQ()
+        {
+            var serviceBusConnection = new ServiceBusConnection(ConnectionString, MessageBrokerDialect.RabbitMQ, new Logger<ServiceBusConnectionTests>(new NullLoggerFactory()));
+            var entityName = serviceBusConnection.GetEntityName("my-queue-name", LinkRole.Sender);
+            Assert.AreEqual("/exchange/NameSpaceTest/my-queue-name", entityName);
+        }
+
+        [TestMethod]
+        public void CanGetEnityNameForReceiverLinkForServiceBus()
+        {
+            var serviceBusConnection = new ServiceBusConnection(ConnectionString, MessageBrokerDialect.ServiceBus, new Logger<ServiceBusConnectionTests>(new NullLoggerFactory()));
+            var entityName = serviceBusConnection.GetEntityName("my-queue-name", LinkRole.Receiver);
+            Assert.AreEqual("NameSpaceTest/my-queue-name", entityName);
+        }
+
+        [TestMethod]
+        public void CanGetEnityNameForSenderLinkForServiceBus()
+        {
+            var serviceBusConnection = new ServiceBusConnection(ConnectionString, MessageBrokerDialect.ServiceBus, new Logger<ServiceBusConnectionTests>(new NullLoggerFactory()));
+            var entityName = serviceBusConnection.GetEntityName("my-queue-name", LinkRole.Sender);
+            Assert.AreEqual("NameSpaceTest/my-queue-name", entityName);
+        }
+    }
+}


### PR DESCRIPTION
This patch adds RabbitMQ dialect specifics for how to build Link Addresses.

For more information on Routing and Addressing in RabbitMQ, see:
https://github.com/rabbitmq/rabbitmq-server/tree/master/deps/rabbitmq_amqp1_0#routing-and-addressing