### PR TITLE
Feature/log messages not envelopedsigned as warning

### DIFF
--- a/Documentation/Konfigurasjon.md
+++ b/Documentation/Konfigurasjon.md
@@ -22,6 +22,7 @@ Dette er et eksempel på hvordan en slik fil kan se ut.
     },
     "MessagingSettings": {
         "MyHerId": "1234",
+        "SystemIdentifier" : "My HN Integrator 13.37",
         "IgnoreCertificateErrorOnSend": "false",
         "ServiceBus": {
             "ConnectionString": "",

--- a/Documentation/Konfigurasjon.md
+++ b/Documentation/Konfigurasjon.md
@@ -23,6 +23,7 @@ Dette er et eksempel på hvordan en slik fil kan se ut.
     "MessagingSettings": {
         "MyHerId": "1234",
         "SystemIdentifier" : "My HN Integrator 13.37",
+        "LogMessagesNotSignedAndEnvelopedAsWarning" : true,
         "IgnoreCertificateErrorOnSend": "false",
         "ServiceBus": {
             "ConnectionString": "",

--- a/Examples/Helsenorge.Messaging.Client/ClientSample.json
+++ b/Examples/Helsenorge.Messaging.Client/ClientSample.json
@@ -13,6 +13,7 @@
     "MyHerId": "1234"
   },
   "MessagingSettings": {
+    "SystemIdentifier" : "",
     "MyHerId": "1234",
     "ServiceBus": {
       "ConnectionString": "???",

--- a/Examples/Helsenorge.Messaging.Client/ClientSample.json
+++ b/Examples/Helsenorge.Messaging.Client/ClientSample.json
@@ -14,6 +14,7 @@
   },
   "MessagingSettings": {
     "SystemIdentifier" : "",
+    "LogMessagesNotSignedAndEnvelopedAsWarning" : true,
     "MyHerId": "1234",
     "ServiceBus": {
       "ConnectionString": "???",

--- a/Examples/Helsenorge.Messaging.Client/appsettings.json
+++ b/Examples/Helsenorge.Messaging.Client/appsettings.json
@@ -26,6 +26,7 @@
         "CachingInterval": "00:05:00"
     },
     "MessagingSettings": {
+        "SystemIdentifier" : "",
         "IgnoreCertificateErrorOnSend": "false",
             "ServiceBus": {
                 "ConnectionString": "",

--- a/Examples/Helsenorge.Messaging.Client/appsettings.json
+++ b/Examples/Helsenorge.Messaging.Client/appsettings.json
@@ -27,6 +27,7 @@
     },
     "MessagingSettings": {
         "SystemIdentifier" : "",
+        "LogMessagesNotSignedAndEnvelopedAsWarning" : true,
         "IgnoreCertificateErrorOnSend": "false",
             "ServiceBus": {
                 "ConnectionString": "",

--- a/Examples/Helsenorge.Messaging.Server/ServerSample.json
+++ b/Examples/Helsenorge.Messaging.Server/ServerSample.json
@@ -13,6 +13,7 @@
         "MyHerId": "6789"
     },
     "MessagingSettings": {
+        "SystemIdentifier" : "Shortname for my application",
         "MyHerId": "6789",
         "ServiceBus": {
             "ConnectionString": "???"

--- a/Examples/Helsenorge.Messaging.Server/ServerSample.json
+++ b/Examples/Helsenorge.Messaging.Server/ServerSample.json
@@ -14,6 +14,7 @@
     },
     "MessagingSettings": {
         "SystemIdentifier" : "Shortname for my application",
+        "LogMessagesNotSignedAndEnvelopedAsWarning" : true,
         "MyHerId": "6789",
         "ServiceBus": {
             "ConnectionString": "???"

--- a/Examples/Helsenorge.Messaging.Server/appsettings.json
+++ b/Examples/Helsenorge.Messaging.Server/appsettings.json
@@ -27,6 +27,7 @@
     },
         "MessagingSettings": {
             "SystemIdentifier" : "",
+            "LogMessagesNotSignedAndEnvelopedAsWarning" : true,
             "IgnoreCertificateErrorOnSend": "false",
             "ServiceBus": {
                 "ConnectionString": "",

--- a/Examples/Helsenorge.Messaging.Server/appsettings.json
+++ b/Examples/Helsenorge.Messaging.Server/appsettings.json
@@ -26,6 +26,7 @@
         "CachingInterval": "00:05:00"
     },
         "MessagingSettings": {
+            "SystemIdentifier" : "",
             "IgnoreCertificateErrorOnSend": "false",
             "ServiceBus": {
                 "ConnectionString": "",

--- a/src/Helsenorge.Messaging/MessagingSettings.cs
+++ b/src/Helsenorge.Messaging/MessagingSettings.cs
@@ -53,6 +53,11 @@ namespace Helsenorge.Messaging
         public bool LogPayload { get; set; }
 
         /// <summary>
+        /// Gets or sets a named identifier for the system running the application
+        /// </summary>
+        public string SystemIdentifier { get; set; }
+
+        /// <summary>
         /// Default contructor
         /// </summary>
         public MessagingSettings()
@@ -104,6 +109,11 @@ namespace Helsenorge.Messaging
         /// Gets or set the Type of Message Broker we are using
         /// </summary>
         public MessageBrokerDialect MessageBrokerDialect { get; set; } = MessageBrokerDialect.ServiceBus;
+
+        /// <summary>
+        /// Gets or sets a named identifier for the system running the application
+        /// </summary>
+        public string SystemIdentifier => _settings.SystemIdentifier;
 
         /// <summary>
         /// Gets or sets the connection string

--- a/src/Helsenorge.Messaging/MessagingSettings.cs
+++ b/src/Helsenorge.Messaging/MessagingSettings.cs
@@ -57,6 +57,12 @@ namespace Helsenorge.Messaging
         /// </summary>
         public string SystemIdentifier { get; set; }
 
+
+        /// <summary>
+        /// Log messages not encrypted and enveloped as Warning
+        /// </summary>
+        public bool LogMessagesNotSignedAndEnvelopedAsWarning { get; set; } = true;
+
         /// <summary>
         /// Default contructor
         /// </summary>
@@ -114,6 +120,11 @@ namespace Helsenorge.Messaging
         /// Gets or sets a named identifier for the system running the application
         /// </summary>
         public string SystemIdentifier => _settings.SystemIdentifier;
+
+        /// <summary>
+        /// Log messages not encrypted and enveloped as Warning
+        /// </summary>
+        public bool LogMessagesNotSignedAndEnvelopedAsWarning => _settings.LogMessagesNotSignedAndEnvelopedAsWarning;
 
         /// <summary>
         /// Gets or sets the connection string

--- a/src/Helsenorge.Messaging/ServiceBus/Receivers/MessageListener.cs
+++ b/src/Helsenorge.Messaging/ServiceBus/Receivers/MessageListener.cs
@@ -322,8 +322,16 @@ namespace Helsenorge.Messaging.ServiceBus.Receivers
         {
             XDocument payload;
 
-            if (contentType.Equals(ContentType.Text, StringComparison.OrdinalIgnoreCase) ||
-                contentType.Equals(ContentType.Soap, StringComparison.OrdinalIgnoreCase))
+            var isPlainText = contentType.Equals(ContentType.Text, StringComparison.OrdinalIgnoreCase);
+            var isSoap = contentType.Equals(ContentType.Text, StringComparison.OrdinalIgnoreCase);
+            var isSignedAndEnveloped = contentType.Equals(ContentType.SignedAndEnveloped, StringComparison.OrdinalIgnoreCase);
+
+            if (!isSoap && !isSignedAndEnveloped)
+            {
+                Logger.LogWarning($"ContentType of message is not according to standard. Expected:{ContentType.SignedAndEnveloped} Actual:{contentType} ");
+            }
+
+            if (isPlainText || isSoap)
             {
                 contentWasSigned = false;
                 // no certificates to validate

--- a/src/Helsenorge.Messaging/ServiceBus/ServiceBusConnection.cs
+++ b/src/Helsenorge.Messaging/ServiceBus/ServiceBusConnection.cs
@@ -39,6 +39,16 @@ namespace Helsenorge.Messaging.ServiceBus
         {
         }
 
+
+        /// <summary>Initializes a new instance of the <see cref="ServiceBusConnection" /> class using the properties in <see cref="ServiceBusSettings"/> settings and a <see cref="ILogger"/> object.</summary>
+        /// <param name="settings"></param>
+        /// <param name="logger"></param>
+        public ServiceBusConnection(ServiceBusSettings settings, ILogger logger)
+        :this(settings.ConnectionString, settings.MessageBrokerDialect, settings.MaxLinksPerSession, settings.MaxSessionsPerConnection, logger)
+        {
+            this.SystemIdent = settings.SystemIdentifier;
+        }
+
         /// <summary>Initializes a new instance of the <see cref="ServiceBusConnection" /> class with the givem connection string and a <see cref="ILogger"/> object.</summary>
         /// <param name="connectionString">The connection used to connect to Message Broker.</param>
         /// <param name="messageBrokerDialect">A <see cref="MessageBrokerDialect"/> which tells ServiceBusConnection what kind of Message Broker we are communicating with.</param>
@@ -87,6 +97,8 @@ namespace Helsenorge.Messaging.ServiceBus
         /// </summary>
         /// <remarks>This only works properly for Microsoft Service Bus.</remarks>
         internal string Namespace { get; }
+
+        public string SystemIdent { get; }
 
         /// <summary>
         /// Returns what kind of Message Broker Dialect we should use.

--- a/src/Helsenorge.Messaging/ServiceBus/ServiceBusFactoryPool.cs
+++ b/src/Helsenorge.Messaging/ServiceBus/ServiceBusFactoryPool.cs
@@ -37,7 +37,7 @@ namespace Helsenorge.Messaging.ServiceBus
         protected override Task<IMessagingFactory> CreateEntity(ILogger logger, string id)
         {
             if (_alternateMessagingFactor != null) return Task.FromResult(_alternateMessagingFactor);
-            var connection = new ServiceBusConnection(_settings.ConnectionString, _settings.MessageBrokerDialect, _settings.MaxLinksPerSession, _settings.MaxSessionsPerConnection, logger);
+            var connection = new ServiceBusConnection(_settings, logger);
             return Task.FromResult<IMessagingFactory>(new ServiceBusFactory(connection, logger));
         }
         public async Task<IMessagingMessage> CreateMessage(ILogger logger, Stream stream)


### PR DESCRIPTION
when messages received is not signed and enveloped a Warning will be logged.
logging is configurable but is default true in code
logging can be turned off setting 
"MessagingSettings"."LogMessagesNotSignedAndEnvelopedAsWarning" : false,
