### PR TITLE
Registries+Tests: Serialize SEID2.0 encryption certificates

### DIFF
--- a/src/Helsenorge.Registries/CollaborationProtocolRegistry.cs
+++ b/src/Helsenorge.Registries/CollaborationProtocolRegistry.cs
@@ -345,7 +345,7 @@ namespace Helsenorge.Registries
                 var base64 = certificateElement.Descendants(xmlSig + "X509Certificate").First().Value;
                 var certificate = new X509Certificate2(Convert.FromBase64String(base64));
 
-                if (certificate.HasKeyUsage(X509KeyUsageFlags.DataEncipherment))
+                if (certificate.HasKeyUsage(X509KeyUsageFlags.KeyEncipherment))
                 {
                     cpa.EncryptionCertificate = certificate;
                 }

--- a/test/Helsenorge.Messaging.Tests/ServiceBus/Senders/AsynchronousSendTests.cs
+++ b/test/Helsenorge.Messaging.Tests/ServiceBus/Senders/AsynchronousSendTests.cs
@@ -161,7 +161,7 @@ namespace Helsenorge.Messaging.Tests.ServiceBus.Senders
         {
             Settings.IgnoreCertificateErrorOnSend = false;
             CertificateValidator.SetError((c, u) => {
-                if (u != X509KeyUsageFlags.DataEncipherment) return CertificateErrors.None;
+                if (u != X509KeyUsageFlags.KeyEncipherment) return CertificateErrors.None;
 
                 return CertificateErrors.Revoked | CertificateErrors.EndDate;
                 });

--- a/test/Helsenorge.Registries.Tests/CertificateValidatorTests.cs
+++ b/test/Helsenorge.Registries.Tests/CertificateValidatorTests.cs
@@ -63,7 +63,7 @@ namespace Helsenorge.Registries.Tests
         public void X509Certificate2Extensions_KeyUsage()
         {
             Assert.IsTrue(TestCertificates.CounterpartyPublicSignature.HasKeyUsage(X509KeyUsageFlags.NonRepudiation));
-            Assert.IsFalse(TestCertificates.CounterpartyPublicSignature.HasKeyUsage(X509KeyUsageFlags.DataEncipherment));
+            Assert.IsFalse(TestCertificates.CounterpartyPublicSignature.HasKeyUsage(X509KeyUsageFlags.KeyEncipherment));
         }
         // don't have a certificate with multiple errors
         //[TestMethod]


### PR DESCRIPTION
This patch makes sure that we serialize the SEID2.0 encryption
certificate we receive from CPPA Registry by identifying the correct
key usage flag.