### PR TITLE
ServiceBus+Core+Examples: Add MessagingSetting.ApplicationProperties and propogate to ServiceBusSender

### DIFF
--- a/Examples/Helsenorge.Messaging.Client/ClientSample.json
+++ b/Examples/Helsenorge.Messaging.Client/ClientSample.json
@@ -14,6 +14,9 @@
   },
   "MessagingSettings": {
     "MyHerId": "1234",
+    "ApplicationProperties": {
+      "X-SystemIdentifier": "SomeSystemIdentifier"
+    },
     "ServiceBus": {
       "ConnectionString": "???",
       "Synchronous": {

--- a/Examples/PooledReceiver/Program.cs
+++ b/Examples/PooledReceiver/Program.cs
@@ -29,7 +29,7 @@ namespace PooledReceiver
                 MessageBrokerDialect = MessageBrokerDialect.RabbitMQ,
             };
 
-            await using var linkFactoryPool = new LinkFactoryPool(settings, loggerFactory.CreateLogger<LinkFactoryPool>());
+            await using var linkFactoryPool = new LinkFactoryPool(loggerFactory.CreateLogger<LinkFactoryPool>(), settings);
             try
             {
                 var receiver = await linkFactoryPool.CreateCachedMessageReceiver(_queue);

--- a/Examples/PooledSender/Program.cs
+++ b/Examples/PooledSender/Program.cs
@@ -31,7 +31,7 @@ namespace PooledSender
                 MessageBrokerDialect = MessageBrokerDialect.RabbitMQ,
             };
 
-            await using var linkFactoryPool = new LinkFactoryPool(settings, loggerFactory.CreateLogger<LinkFactoryPool>());
+            await using var linkFactoryPool = new LinkFactoryPool(loggerFactory.CreateLogger<LinkFactoryPool>(), settings);
             try
             {
                 var messageCount = 20;

--- a/Examples/PooledSender/Program.cs
+++ b/Examples/PooledSender/Program.cs
@@ -25,13 +25,17 @@ namespace PooledSender
         static async Task Main(string[] args)
         {
             var loggerFactory = new LoggerFactory();
-            var settings = new ServiceBusSettings
+            var settings = new MessagingSettings
             {
-                ConnectionString = _connectionString,
-                MessageBrokerDialect = MessageBrokerDialect.RabbitMQ,
+                ApplicationProperties = {{ "X-SystemIdentifier", "ExampleSystemIdentifier" }},
+                ServiceBus =
+                {
+                    ConnectionString = _connectionString,
+                    MessageBrokerDialect = MessageBrokerDialect.RabbitMQ,
+                }
             };
 
-            await using var linkFactoryPool = new LinkFactoryPool(loggerFactory.CreateLogger<LinkFactoryPool>(), settings);
+            await using var linkFactoryPool = new LinkFactoryPool(loggerFactory.CreateLogger<LinkFactoryPool>(), settings.ServiceBus, settings.ApplicationProperties);
             try
             {
                 var messageCount = 20;

--- a/src/Helsenorge.Messaging/ApplicationPropertiesExtensions.cs
+++ b/src/Helsenorge.Messaging/ApplicationPropertiesExtensions.cs
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2022, Norsk Helsenett SF and contributors
+ * See the file CONTRIBUTORS for details.
+ *
+ * This file is licensed under the MIT license
+ * available at https://raw.githubusercontent.com/helsenorge/Helsenorge.Messaging/master/LICENSE
+ */
+
+using System.Collections.Generic;
+using Amqp.Framing;
+
+namespace Helsenorge.Messaging
+{
+    internal static class ApplicationPropertiesExtensions
+    {
+        public static void AddApplicationProperties(this ApplicationProperties applicationProperties, IDictionary<string, object> properties)
+        {
+            foreach (var property in properties)
+                applicationProperties[property.Key] = property.Value;
+        }
+    }
+}

--- a/src/Helsenorge.Messaging/MessagingSettings.cs
+++ b/src/Helsenorge.Messaging/MessagingSettings.cs
@@ -1,5 +1,5 @@
 /* 
- * Copyright (c) 2020-2021, Norsk Helsenett SF and contributors
+ * Copyright (c) 2020-2022, Norsk Helsenett SF and contributors
  * See the file CONTRIBUTORS for details.
  * 
  * This file is licensed under the MIT license
@@ -51,6 +51,11 @@ namespace Helsenorge.Messaging
         /// Indicates if the payload should be logged. This is false by default since the payload can contain sensitive information
         /// </summary>
         public bool LogPayload { get; set; }
+
+        /// <summary>
+        /// A Dictionary with additional application properties which will be added to <see cref="Amqp.Message"/>.
+        /// </summary>
+        public IDictionary<string, object> ApplicationProperties { get; } = new Dictionary<string, object>();
 
         /// <summary>
         /// Default contructor

--- a/src/Helsenorge.Messaging/ServiceBus/LinkFactory.cs
+++ b/src/Helsenorge.Messaging/ServiceBus/LinkFactory.cs
@@ -1,11 +1,12 @@
 ﻿/*
- * Copyright (c) 2021, Norsk Helsenett SF and contributors
+ * Copyright (c) 2021-2022, Norsk Helsenett SF and contributors
  * See the file CONTRIBUTORS for details.
  *
  * This file is licensed under the MIT license
  * available at https://raw.githubusercontent.com/helsenorge/Helsenorge.Messaging/master/LICENSE
  */
 
+using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
 using Amqp;
@@ -22,14 +23,17 @@ namespace Helsenorge.Messaging.ServiceBus
     {
         private readonly ServiceBusConnection _connection;
         private readonly ILogger<LinkFactory> _logger;
+        private readonly IDictionary<string, object> _applicationProperties;
 
         /// <summary>Initializes a new instance of the <see cref="LinkFactory" /> class with a <see cref="ServiceBusConnection"/> and a <see cref="ILogger{LinkFactory}"/>.</summary>
         /// <param name="connection">A <see cref="ServiceBusConnection"/> that represents the connection to ServiecBus.</param>
         /// <param name="logger">A <see cref="ILogger{LinkFactory}"/> which will be used to log errors and information.</param>
-        public LinkFactory(ServiceBusConnection connection, ILogger<LinkFactory> logger)
+        /// <param name="applicationProperties">A Dictionary with additional application properties which will be added to <see cref="Amqp.Message"/>.</param>
+        public LinkFactory(ServiceBusConnection connection, ILogger<LinkFactory> logger, IDictionary<string, object> applicationProperties = null)
         {
             _connection = connection;
             _logger = logger;
+            _applicationProperties = applicationProperties;
         }
 
         /// <summary>Creates a Receiver Link of type <see cref="IMessagingReceiver"/>.</summary>
@@ -43,7 +47,7 @@ namespace Helsenorge.Messaging.ServiceBus
         /// <param name="queue">The path to the queue you want to receive messages from.</param>
         /// <returns>A <see cref="IMessagingSender"/></returns>
         public IMessagingSender CreateSender(string queue)
-            => new ServiceBusSender(_connection, queue, _logger);
+            => new ServiceBusSender(_logger, _connection, queue, _applicationProperties);
 
         /// <summary>Creates a <see cref="IMessagingMessage"/>.</summary>
         /// <param name="fromHerId">The HER-id which is the receipient of the message</param>

--- a/src/Helsenorge.Messaging/ServiceBus/LinkFactoryPool.cs
+++ b/src/Helsenorge.Messaging/ServiceBus/LinkFactoryPool.cs
@@ -1,5 +1,5 @@
 ﻿/*
- * Copyright (c) 2021, Norsk Helsenett SF and contributors
+ * Copyright (c) 2021-2022, Norsk Helsenett SF and contributors
  * See the file CONTRIBUTORS for details.
  *
  * This file is licensed under the MIT license
@@ -7,6 +7,7 @@
  */
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
 using Amqp;
@@ -21,8 +22,9 @@ namespace Helsenorge.Messaging.ServiceBus
     /// </summary>
     public class LinkFactoryPool : IAsyncDisposable
     {
-        private readonly ServiceBusSettings _settings;
         private readonly ILogger _logger;
+        private readonly ServiceBusSettings _settings;
+        private readonly IDictionary<string, object> _applicationProperties;
         private readonly ServiceBusFactoryPool _factoryPool;
         private readonly ServiceBusReceiverPool _receiverPool;
         private readonly ServiceBusSenderPool _senderPool;
@@ -30,12 +32,14 @@ namespace Helsenorge.Messaging.ServiceBus
         /// <summary>Initializes a new instance of the <see cref="LinkFactoryPool" /> class with a <see cref="ServiceBusSettings"/> and a <see cref="ILogger"/>.</summary>
         /// <param name="settings">A <see cref="ServiceBusSettings"/> instance that contains the settings.</param>
         /// <param name="logger">An <see cref="ILogger"/> instance which will be used to log errors and information.</param>
-        public LinkFactoryPool(ServiceBusSettings settings, ILogger logger)
+        /// <param name="applicationProperties">A Dictionary with additional application properties which will be added to <see cref="Amqp.Message"/>.</param>
+        public LinkFactoryPool(ILogger logger, ServiceBusSettings settings, IDictionary<string, object> applicationProperties = null)
         {
-            _settings = settings;
             _logger = logger;
+            _settings = settings;
+            _applicationProperties = applicationProperties;
 
-            _factoryPool = new ServiceBusFactoryPool(_settings);
+            _factoryPool = new ServiceBusFactoryPool(_settings, _applicationProperties);
             _receiverPool = new ServiceBusReceiverPool(_settings, _factoryPool);
             _senderPool = new ServiceBusSenderPool(_settings, _factoryPool);
         }

--- a/src/Helsenorge.Messaging/ServiceBus/ServiceBusCore.cs
+++ b/src/Helsenorge.Messaging/ServiceBus/ServiceBusCore.cs
@@ -1,5 +1,5 @@
 /* 
- * Copyright (c) 2020, Norsk Helsenett SF and contributors
+ * Copyright (c) 2020-2022, Norsk Helsenett SF and contributors
  * See the file CONTRIBUTORS for details.
  * 
  * This file is licensed under the MIT license
@@ -84,7 +84,7 @@ namespace Helsenorge.Messaging.ServiceBus
             }
             else
             {
-                FactoryPool = new ServiceBusFactoryPool(core.Settings.ServiceBus);
+                FactoryPool = new ServiceBusFactoryPool(core.Settings.ServiceBus, core.Settings.ApplicationProperties);
             }
             
             SenderPool = new ServiceBusSenderPool(core.Settings.ServiceBus, FactoryPool);

--- a/src/Helsenorge.Messaging/ServiceBus/ServiceBusFactory.cs
+++ b/src/Helsenorge.Messaging/ServiceBus/ServiceBusFactory.cs
@@ -1,5 +1,5 @@
 ﻿/* 
- * Copyright (c) 2020, Norsk Helsenett SF and contributors
+ * Copyright (c) 2020-2022, Norsk Helsenett SF and contributors
  * See the file CONTRIBUTORS for details.
  * 
  * This file is licensed under the MIT license
@@ -7,6 +7,7 @@
  */
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Threading.Tasks;
@@ -20,13 +21,15 @@ namespace Helsenorge.Messaging.ServiceBus
     [ExcludeFromCodeCoverage]
     internal class ServiceBusFactory : IMessagingFactory
     {
-        private readonly ServiceBusConnection _connection;
         private readonly ILogger _logger;
+        private readonly ServiceBusConnection _connection;
+        private readonly IDictionary<string, object> _applicationProperties;
 
-        public ServiceBusFactory(ServiceBusConnection connection, ILogger logger)
+        public ServiceBusFactory(ILogger logger, ServiceBusConnection connection, IDictionary<string, object> applicationProperties)
         {
-            _connection = connection ?? throw new ArgumentNullException(nameof(connection));
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            _connection = connection ?? throw new ArgumentNullException(nameof(connection));
+            _applicationProperties = applicationProperties;
         }
 
         public IMessagingReceiver CreateMessageReceiver(string id, int credit)
@@ -36,7 +39,7 @@ namespace Helsenorge.Messaging.ServiceBus
 
         public IMessagingSender CreateMessageSender(string id)
         {
-            return new ServiceBusSender(_connection, id, _logger);
+            return new ServiceBusSender(_logger, _connection, id, _applicationProperties);
         }
 
         public bool IsClosed => _connection.IsClosedOrClosing;

--- a/test/Helsenorge.Messaging.IntegrationTests/ServiceBus/ServiceBusFixture.cs
+++ b/test/Helsenorge.Messaging.IntegrationTests/ServiceBus/ServiceBusFixture.cs
@@ -65,7 +65,7 @@ namespace Helsenorge.Messaging.IntegrationTests.ServiceBus
 
         public ServiceBusSender CreateSender(string queueName)
         {
-            return new ServiceBusSender(Connection, queueName, _logger);
+            return new ServiceBusSender(_logger, Connection, queueName);
         }
 
         public async Task<List<Message>> ReadAllMessagesAsync(string queueName, bool accept = false)


### PR DESCRIPTION
### ServiceBus: Add ApplicationProperties and propogate to ServiceBusSender
This adds the property MessagingSettings.ApplicationProperties which
lets users of the API to add custom Application Properties which will be
propogated to ServiceBusSender and applied to Amqp.Message before we
send the message.

This enables us to easily add additional required Amqp.Message
ApplicationProperties at a later stage.

### Core: Enrich ApplicationProperties with System Information
This lets us enrich the MessagingSettings.ApplicationProperties with
additonal System Information, such as:

- Full name of Executing Assembly
- Version of Executing Assembly
- Target Framework the Entry Assembly is running under
- Host name of that host

This will be valuable information for Operations when troubleshooting
support issues for the clients.

### Examples: Update Client and PooledSender showcasing 'X-SystemIdentifier'