### PR TITLE
Update exception logging text in CollaborationProtocolRegistry

### DIFF
--- a/src/Helsenorge.Registries/CollaborationProtocolRegistry.cs
+++ b/src/Helsenorge.Registries/CollaborationProtocolRegistry.cs
@@ -102,7 +102,7 @@ namespace Helsenorge.Registries
             catch (FaultException<CPAService.GenericFault> ex)
             {
                 // if this happens, we fall back to the dummy profile further down
-                logger.LogWarning($"Error resolving protocol for counterparty. ErrorCode: {ex.Detail.ErrorCode} Message: {ex.Detail.Message}");
+                logger.LogWarning($"Could not find or resolve protocol for counterparty when using HerId {counterpartyHerId}. ErrorCode: {ex.Detail.ErrorCode} Message: {ex.Detail.Message}");
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
When this exception gets logged, its very hard to understand what has happened. Especially when the person reading the log has no context for the warning.
This is an attempt to make the log message a bit less cryptic and allow the end user to debug what HerId fails, without having to log debug.