### PR TITLE
ServiceBus: Log warnings for non-encrypted and non-signed payloads

### DIFF
--- a/src/Helsenorge.Messaging/MessagingSettings.cs
+++ b/src/Helsenorge.Messaging/MessagingSettings.cs
@@ -158,6 +158,10 @@ namespace Helsenorge.Messaging
         /// The max cache entries our recycling process will handle each time it is triggered.
         /// </summary>
         public ushort MaxCacheEntryTrimCount { get; set; } = DefaultMaxCacheEntryTrimCount;
+        /// <summary>
+        /// Log messages not encrypted and enveloped as Warning
+        /// </summary>
+        public bool LogMessagesNotSignedAndEnvelopedAsWarning { get; set; } = true;
 
         /// <summary>
         /// The Her id that we represent


### PR DESCRIPTION
Adds a configuration option to enable warnings in the logs for
non-encrypted and non-signed payloads.

The configuration option defaults to true and is named
'LogMessagesNotSignedAndEnvelopedAsWarning'.