### PR TITLE
deps: Remove non-necessary dependencies

### DIFF
--- a/Examples/Helsenorge.Messaging.Client/Helsenorge.Messaging.Client.csproj
+++ b/Examples/Helsenorge.Messaging.Client/Helsenorge.Messaging.Client.csproj
@@ -19,7 +19,6 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.23" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.23" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.1.23" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="3.1.23" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="3.1.23" />
   </ItemGroup>
   <ItemGroup>

--- a/Examples/Helsenorge.Messaging.Server/Helsenorge.Messaging.Server.csproj
+++ b/Examples/Helsenorge.Messaging.Server/Helsenorge.Messaging.Server.csproj
@@ -19,7 +19,6 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.23" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.23" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.1.23" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="3.1.23" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="3.1.23" />
     <PackageReference Include="NLog" Version="4.7.14" />
     <PackageReference Include="System.Security.Cryptography.Algorithms" Version="4.3.1" />

--- a/Examples/PooledReceiver/PooledReceiver.csproj
+++ b/Examples/PooledReceiver/PooledReceiver.csproj
@@ -7,7 +7,6 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
       <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.23" />
     </ItemGroup>
 

--- a/Examples/PooledSender/PooledSender.csproj
+++ b/Examples/PooledSender/PooledSender.csproj
@@ -10,8 +10,4 @@
       <ProjectReference Include="..\..\src\Helsenorge.Messaging\Helsenorge.Messaging.csproj" />
     </ItemGroup>
 
-    <ItemGroup>
-      <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
-    </ItemGroup>
-
 </Project>

--- a/src/Helsenorge.Messaging/Helsenorge.Messaging.csproj
+++ b/src/Helsenorge.Messaging/Helsenorge.Messaging.csproj
@@ -15,10 +15,8 @@
   <ItemGroup>
     <PackageReference Include="AMQPNetLite" Version="2.4.4" />
     <PackageReference Include="AMQPNetLite.Serialization" Version="2.4.4" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="3.1.23" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="3.1.23" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.23" />
-    <PackageReference Include="System.Security.Cryptography.Algorithms" Version="4.3.1" />
     <PackageReference Include="System.Security.Cryptography.Pkcs" Version="5.0.1" />
   </ItemGroup>
 

--- a/src/Helsenorge.Registries/Helsenorge.Registries.csproj
+++ b/src/Helsenorge.Registries/Helsenorge.Registries.csproj
@@ -20,7 +20,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="3.1.23" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.1.23" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.23" />
     <PackageReference Include="System.ServiceModel.Http" Version="4.9.0" />
     <PackageReference Include="System.ServiceModel.NetTcp" Version="4.9.0" />

--- a/test/Helsenorge.Messaging.Tests/Helsenorge.Messaging.Tests.csproj
+++ b/test/Helsenorge.Messaging.Tests/Helsenorge.Messaging.Tests.csproj
@@ -13,7 +13,6 @@
         <SignAssembly>false</SignAssembly>
     </PropertyGroup>
   <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="3.1.23" />
         <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="3.1.23" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
         <PackageReference Include="Moq" Version="4.17.2" />


### PR DESCRIPTION
These dependencies are not needed for our libraries to build since there
are no direct dependencies on them.