### PR TITLE
ServiceBus: Make internal Exceptions public

### DIFF
--- a/src/Helsenorge.Messaging/ServiceBus/Exceptions/DecodeErrorException.cs
+++ b/src/Helsenorge.Messaging/ServiceBus/Exceptions/DecodeErrorException.cs
@@ -10,7 +10,7 @@ using System;
 
 namespace Helsenorge.Messaging.ServiceBus.Exceptions
 {
-    internal class DecodeErrorException : ServiceBusException
+    public class DecodeErrorException : ServiceBusException
     {
         public DecodeErrorException(string message)
             : this(message, null)

--- a/src/Helsenorge.Messaging/ServiceBus/Exceptions/FrameSizeTooSmallException.cs
+++ b/src/Helsenorge.Messaging/ServiceBus/Exceptions/FrameSizeTooSmallException.cs
@@ -10,7 +10,7 @@ using System;
 
 namespace Helsenorge.Messaging.ServiceBus.Exceptions
 {
-    internal class FrameSizeTooSmallException : ServiceBusException
+    public class FrameSizeTooSmallException : ServiceBusException
     {
         public FrameSizeTooSmallException(string message)
             : this(message, null)

--- a/src/Helsenorge.Messaging/ServiceBus/Exceptions/FramingErrorException.cs
+++ b/src/Helsenorge.Messaging/ServiceBus/Exceptions/FramingErrorException.cs
@@ -10,7 +10,7 @@ using System;
 
 namespace Helsenorge.Messaging.ServiceBus.Exceptions
 {
-    internal class FramingErrorException : ServiceBusException
+    public class FramingErrorException : ServiceBusException
     {
         public FramingErrorException(string message)
             : this(message, null)

--- a/src/Helsenorge.Messaging/ServiceBus/Exceptions/InternalErrorException.cs
+++ b/src/Helsenorge.Messaging/ServiceBus/Exceptions/InternalErrorException.cs
@@ -10,7 +10,7 @@ using System;
 
 namespace Helsenorge.Messaging.ServiceBus.Exceptions
 {
-    internal class InternalErrorException : ServiceBusException
+    public class InternalErrorException : ServiceBusException
     {
         public InternalErrorException(string message)
             : this(message, null)

--- a/src/Helsenorge.Messaging/ServiceBus/Exceptions/InvalidFieldException.cs
+++ b/src/Helsenorge.Messaging/ServiceBus/Exceptions/InvalidFieldException.cs
@@ -10,7 +10,7 @@ using System;
 
 namespace Helsenorge.Messaging.ServiceBus.Exceptions
 {
-    class InvalidFieldException : ServiceBusException
+    public class InvalidFieldException : ServiceBusException
     {
         public InvalidFieldException(string message)
             : this(message, null)

--- a/src/Helsenorge.Messaging/ServiceBus/Exceptions/MessageLockLostException.cs
+++ b/src/Helsenorge.Messaging/ServiceBus/Exceptions/MessageLockLostException.cs
@@ -13,7 +13,7 @@ namespace Helsenorge.Messaging.ServiceBus.Exceptions
     /// <summary>
     /// The exception that is thrown when the lock on the message is lost.  Callers should call Receive and process the message again.
     /// </summary>
-    internal sealed class MessageLockLostException : ServiceBusException
+    public sealed class MessageLockLostException : ServiceBusException
     {
         public MessageLockLostException(string message)
             : base(message, null)

--- a/src/Helsenorge.Messaging/ServiceBus/Exceptions/MessageNotFoundException.cs
+++ b/src/Helsenorge.Messaging/ServiceBus/Exceptions/MessageNotFoundException.cs
@@ -13,7 +13,7 @@ namespace Helsenorge.Messaging.ServiceBus.Exceptions
     /// <summary>
     /// The exception that is thrown when the requested message is not found.
     /// </summary>
-    internal sealed class MessageNotFoundException : ServiceBusException
+    public sealed class MessageNotFoundException : ServiceBusException
     {
         public MessageNotFoundException(string message)
             : this(message, null)

--- a/src/Helsenorge.Messaging/ServiceBus/Exceptions/MessageReleasedException.cs
+++ b/src/Helsenorge.Messaging/ServiceBus/Exceptions/MessageReleasedException.cs
@@ -10,7 +10,7 @@ using System;
 
 namespace Helsenorge.Messaging.ServiceBus.Exceptions
 {
-    internal class MessageReleasedException : ServiceBusException
+    public class MessageReleasedException : ServiceBusException
     {
         public MessageReleasedException(string message)
             : this(message, null)

--- a/src/Helsenorge.Messaging/ServiceBus/Exceptions/MessageSizeExceededException.cs
+++ b/src/Helsenorge.Messaging/ServiceBus/Exceptions/MessageSizeExceededException.cs
@@ -13,7 +13,7 @@ namespace Helsenorge.Messaging.ServiceBus.Exceptions
     /// <summary>
     /// The exception that is thrown when the message size exceeds the limit.
     /// </summary>
-    internal sealed class MessageSizeExceededException : ServiceBusException
+    public sealed class MessageSizeExceededException : ServiceBusException
     {
         public MessageSizeExceededException(string message)
             : this(message, null)

--- a/src/Helsenorge.Messaging/ServiceBus/Exceptions/MessagingEntityAlreadyExistsException.cs
+++ b/src/Helsenorge.Messaging/ServiceBus/Exceptions/MessagingEntityAlreadyExistsException.cs
@@ -13,7 +13,7 @@ namespace Helsenorge.Messaging.ServiceBus.Exceptions
     /// <summary>
     /// The exception that is thrown when an already existing entity is being re created.
     /// </summary>
-    internal class MessagingEntityAlreadyExistsException : ServiceBusException
+    public class MessagingEntityAlreadyExistsException : ServiceBusException
     {
         public MessagingEntityAlreadyExistsException(string message) : this(message, null)
         {

--- a/src/Helsenorge.Messaging/ServiceBus/Exceptions/MessagingEntityDisabledException.cs
+++ b/src/Helsenorge.Messaging/ServiceBus/Exceptions/MessagingEntityDisabledException.cs
@@ -13,7 +13,7 @@ namespace Helsenorge.Messaging.ServiceBus.Exceptions
     /// <summary>
     /// The exception that is thrown when the Messaging Entity is disabled. Enable the entity again using Portal.
     /// </summary>
-    internal sealed class MessagingEntityDisabledException : ServiceBusException
+    public sealed class MessagingEntityDisabledException : ServiceBusException
     {
         public MessagingEntityDisabledException(string message)
             : this(message, null)

--- a/src/Helsenorge.Messaging/ServiceBus/Exceptions/MessagingEntityNotFoundException.cs
+++ b/src/Helsenorge.Messaging/ServiceBus/Exceptions/MessagingEntityNotFoundException.cs
@@ -13,7 +13,7 @@ namespace Helsenorge.Messaging.ServiceBus.Exceptions
     /// <summary>
     /// The exception that is thrown when the Messaging Entity is not found.  Verify Entity Exists.
     /// </summary>
-    internal sealed class MessagingEntityNotFoundException : ServiceBusException
+    public sealed class MessagingEntityNotFoundException : ServiceBusException
     {
         public MessagingEntityNotFoundException(string message)
             : this(message, null)

--- a/src/Helsenorge.Messaging/ServiceBus/Exceptions/QuotaExceededException.cs
+++ b/src/Helsenorge.Messaging/ServiceBus/Exceptions/QuotaExceededException.cs
@@ -14,7 +14,7 @@ namespace Helsenorge.Messaging.ServiceBus.Exceptions
     /// The exception that is thrown when the Quota (Entity Max Size or other Connection etc) allocated to the Entity has exceeded.  Callers should check the
     /// error message to see which of the Quota exceeded and take appropriate action.
     /// </summary>
-    internal sealed class QuotaExceededException : ServiceBusException
+    public sealed class QuotaExceededException : ServiceBusException
     {
         public QuotaExceededException(string message)
             : this(message, null)

--- a/src/Helsenorge.Messaging/ServiceBus/Exceptions/RecoverableServiceBusException.cs
+++ b/src/Helsenorge.Messaging/ServiceBus/Exceptions/RecoverableServiceBusException.cs
@@ -10,7 +10,7 @@ using System;
 
 namespace Helsenorge.Messaging.ServiceBus.Exceptions
 {
-    internal sealed class RecoverableServiceBusException : ServiceBusException
+    public sealed class RecoverableServiceBusException : ServiceBusException
     {
         public RecoverableServiceBusException(string message) : base(message)
         {

--- a/src/Helsenorge.Messaging/ServiceBus/Exceptions/ResourceDeletedException.cs
+++ b/src/Helsenorge.Messaging/ServiceBus/Exceptions/ResourceDeletedException.cs
@@ -10,7 +10,7 @@ using System;
 
 namespace Helsenorge.Messaging.ServiceBus.Exceptions
 {
-    internal class ResourceDeletedException : ServiceBusException
+    public class ResourceDeletedException : ServiceBusException
     {
         public ResourceDeletedException(string message)
             : this(message, null)

--- a/src/Helsenorge.Messaging/ServiceBus/Exceptions/ResourceLockedException.cs
+++ b/src/Helsenorge.Messaging/ServiceBus/Exceptions/ResourceLockedException.cs
@@ -10,7 +10,7 @@ using System;
 
 namespace Helsenorge.Messaging.ServiceBus.Exceptions
 {
-    internal class ResourceLockedException : ServiceBusException
+    public class ResourceLockedException : ServiceBusException
     {
         public ResourceLockedException(string message)
             : this(message, null)

--- a/src/Helsenorge.Messaging/ServiceBus/Exceptions/ServerBusyException.cs
+++ b/src/Helsenorge.Messaging/ServiceBus/Exceptions/ServerBusyException.cs
@@ -13,7 +13,7 @@ namespace Helsenorge.Messaging.ServiceBus.Exceptions
     /// <summary>
     /// The exception that is thrown when a server is busy.  Callers should wait a while and retry the operation.
     /// </summary>
-    internal sealed class ServerBusyException : ServiceBusException
+    public sealed class ServerBusyException : ServiceBusException
     {
         public ServerBusyException(string message)
             : this(message, null)

--- a/src/Helsenorge.Messaging/ServiceBus/Exceptions/ServiceBusCommunicationException.cs
+++ b/src/Helsenorge.Messaging/ServiceBus/Exceptions/ServiceBusCommunicationException.cs
@@ -13,7 +13,7 @@ namespace Helsenorge.Messaging.ServiceBus.Exceptions
     /// <summary>
     /// Exception for signaling general communication errors related to messaging operations.
     /// </summary>
-    internal class ServiceBusCommunicationException : ServiceBusException
+    public class ServiceBusCommunicationException : ServiceBusException
     {
         public ServiceBusCommunicationException(string message)
             : this(message, null)

--- a/src/Helsenorge.Messaging/ServiceBus/Exceptions/ServiceBusException.cs
+++ b/src/Helsenorge.Messaging/ServiceBus/Exceptions/ServiceBusException.cs
@@ -10,7 +10,7 @@ using System;
 
 namespace Helsenorge.Messaging.ServiceBus.Exceptions
 {
-    internal abstract class ServiceBusException : Exception
+    public abstract class ServiceBusException : Exception
     {
         public abstract bool CanRetry { get; }
 

--- a/src/Helsenorge.Messaging/ServiceBus/Exceptions/ServiceBusTimeoutException.cs
+++ b/src/Helsenorge.Messaging/ServiceBus/Exceptions/ServiceBusTimeoutException.cs
@@ -13,7 +13,7 @@ namespace Helsenorge.Messaging.ServiceBus.Exceptions
     /// <summary>
     /// The exception that is thrown when a time out is encountered.  Callers retry the operation.
     /// </summary>
-    internal class ServiceBusTimeoutException : ServiceBusException
+    public class ServiceBusTimeoutException : ServiceBusException
     {
         public ServiceBusTimeoutException(string message) : this(message, null)
         {

--- a/src/Helsenorge.Messaging/ServiceBus/Exceptions/SessionCannotBeLockedException.cs
+++ b/src/Helsenorge.Messaging/ServiceBus/Exceptions/SessionCannotBeLockedException.cs
@@ -13,7 +13,7 @@ namespace Helsenorge.Messaging.ServiceBus.Exceptions
     /// <summary>
     /// The exception that is thrown when a session cannot be locked.
     /// </summary>
-    internal sealed class SessionCannotBeLockedException : ServiceBusException
+    public sealed class SessionCannotBeLockedException : ServiceBusException
     {
         public SessionCannotBeLockedException(string message)
             : this(message, null)

--- a/src/Helsenorge.Messaging/ServiceBus/Exceptions/SessionLockLostException.cs
+++ b/src/Helsenorge.Messaging/ServiceBus/Exceptions/SessionLockLostException.cs
@@ -13,7 +13,7 @@ namespace Helsenorge.Messaging.ServiceBus.Exceptions
     /// <summary>
     /// The exception that is thrown when the lock on the Session has expired.  Callers should receive the Session again.
     /// </summary>
-    internal sealed class SessionLockLostException : ServiceBusException
+    public sealed class SessionLockLostException : ServiceBusException
     {
         public SessionLockLostException(string message)
             : this(message, null)

--- a/src/Helsenorge.Messaging/ServiceBus/Exceptions/TransferLimitExceededException.cs
+++ b/src/Helsenorge.Messaging/ServiceBus/Exceptions/TransferLimitExceededException.cs
@@ -13,7 +13,7 @@ namespace Helsenorge.Messaging.ServiceBus.Exceptions
     /// <summary>
     /// The exception that is thrown when message transfers exceeds the limit currently allowed on the link
     /// </summary>
-    internal class TransferLimitExceededException : ServiceBusException
+    public class TransferLimitExceededException : ServiceBusException
     {
         public TransferLimitExceededException(string message)
             : this(message, null)

--- a/src/Helsenorge.Messaging/ServiceBus/Exceptions/UnauthorizedException.cs
+++ b/src/Helsenorge.Messaging/ServiceBus/Exceptions/UnauthorizedException.cs
@@ -13,7 +13,7 @@ namespace Helsenorge.Messaging.ServiceBus.Exceptions
     /// <summary>
     /// The exception that is thrown when user doesn't have access to the entity.
     /// </summary>
-    internal sealed class UnauthorizedException : ServiceBusException
+    public sealed class UnauthorizedException : ServiceBusException
     {
         public UnauthorizedException(string message)
             : this(message, null)

--- a/src/Helsenorge.Messaging/ServiceBus/Exceptions/UncategorizedServiceBusException.cs
+++ b/src/Helsenorge.Messaging/ServiceBus/Exceptions/UncategorizedServiceBusException.cs
@@ -10,7 +10,7 @@ using System;
 
 namespace Helsenorge.Messaging.ServiceBus.Exceptions
 {
-    internal sealed class UncategorizedServiceBusException : ServiceBusException
+    public sealed class UncategorizedServiceBusException : ServiceBusException
     {
         public UncategorizedServiceBusException(string message) : base(message)
         {

--- a/src/Helsenorge.Messaging/ServiceBus/Exceptions/UnexpectedAmqpIdentifierException.cs
+++ b/src/Helsenorge.Messaging/ServiceBus/Exceptions/UnexpectedAmqpIdentifierException.cs
@@ -17,7 +17,7 @@ namespace Helsenorge.Messaging.ServiceBus.Exceptions
     /// The identifier type may be valid within the AMQP specification, but Helsenorge.Messaging does not support the identifier type.
     /// Valid types are <see cref="System.String"/> and <see cref="System.Guid"/>
     /// </remarks>
-    internal class UnexpectedMessageIdentifierTypeException : ServiceBusException
+    public class UnexpectedMessageIdentifierTypeException : ServiceBusException
     {
         public UnexpectedMessageIdentifierTypeException(string message) : base(message)
         {


### PR DESCRIPTION
These internal exceptions can be bubbled outside the library and therefore be accessible for external clients. It is therefore a good practice to make these publicly available.