### PR TITLE
ServiceBus: Make sure that _applicationProperties is always instantiated 

### DIFF
--- a/src/Helsenorge.Messaging/ServiceBus/LinkFactory.cs
+++ b/src/Helsenorge.Messaging/ServiceBus/LinkFactory.cs
@@ -33,7 +33,7 @@ namespace Helsenorge.Messaging.ServiceBus
         {
             _connection = connection;
             _logger = logger;
-            _applicationProperties = applicationProperties;
+            _applicationProperties = applicationProperties ?? new Dictionary<string, object>();
         }
 
         /// <summary>Creates a Receiver Link of type <see cref="IMessagingReceiver"/>.</summary>

--- a/src/Helsenorge.Messaging/ServiceBus/LinkFactoryPool.cs
+++ b/src/Helsenorge.Messaging/ServiceBus/LinkFactoryPool.cs
@@ -37,7 +37,7 @@ namespace Helsenorge.Messaging.ServiceBus
         {
             _logger = logger;
             _settings = settings;
-            _applicationProperties = applicationProperties;
+            _applicationProperties = applicationProperties ?? new Dictionary<string, object>();
 
             _factoryPool = new ServiceBusFactoryPool(_settings, _applicationProperties);
             _receiverPool = new ServiceBusReceiverPool(_settings, _factoryPool);


### PR DESCRIPTION
This makes sure we that instantiate _applicationProperties in LinkFactory and LinkFactoryPool.