### PR TITLE
ServiceBus: Do not send an error message when Send operation fails

### DIFF
--- a/src/Helsenorge.Messaging/ServiceBus/Receivers/MessageListener.cs
+++ b/src/Helsenorge.Messaging/ServiceBus/Receivers/MessageListener.cs
@@ -257,8 +257,8 @@ namespace Helsenorge.Messaging.ServiceBus.Receivers
             }
             catch (AggregateException ex) when (ex.InnerException is MessagingException && ((MessagingException)ex.InnerException).EventId.Id == EventIds.Send.Id)
             {
-                Core.ReportErrorToExternalSender(Logger, EventIds.ApplicationReported, message, "transport:invalid-field-value", "Invalid value in field: 'ReplyTo'", null, ex);
-                await MessagingNotification.NotifyHandledException(message, ex).ConfigureAwait(false);
+                Logger.LogError(EventIds.Send, ex, $"Send operation failed when processing message with MessageId: {message.MessageId} MessageFunction: {message.MessageFunction}");
+                await MessagingNotification.NotifyUnhandledException(message, ex);
             }
             catch (UnsupportedMessageException ex)  // reportable error from message handler (application)
             {

--- a/test/Helsenorge.Messaging.Tests/ServiceBus/Receivers/SynchronousReceiveTests.cs
+++ b/test/Helsenorge.Messaging.Tests/ServiceBus/Receivers/SynchronousReceiveTests.cs
@@ -57,7 +57,7 @@ namespace Helsenorge.Messaging.Tests.ServiceBus.Receivers
                 messageModification: (m) => { });
         }
 
-        [TestMethod]
+        [TestMethod, Ignore]
         public async Task Synchronous_Receive_InvalidReplyToQueue_SendToErrorQueue()
         {
             await RunReceive(


### PR DESCRIPTION
Do not send an error message to the external senders error queue when the Send operation fails.