### PR TITLE
Remove outdated comment in

### DIFF
--- a/src/Helsenorge.Messaging/Abstractions/ICachedMessagingEntity.cs
+++ b/src/Helsenorge.Messaging/Abstractions/ICachedMessagingEntity.cs
@@ -11,7 +11,6 @@ namespace Helsenorge.Messaging.Abstractions
 {
     /// <summary>
     /// Interface for items in <see cref="MessagingEntityCache{T}"/>
-    /// Since those operations are thread safe (locking) we don't support async methods
     /// </summary>
     public interface ICachedMessagingEntity
     {


### PR DESCRIPTION
commit 0a9526a798884a7dc40830d1d8621ba5a41004d1 implemented async on Close so this line of the comment appears to be outdated.