### PR TITLE
Registries: Added optional XML cache formatter

### DIFF
--- a/src/Helsenorge.Registries/AddressRegistry.cs
+++ b/src/Helsenorge.Registries/AddressRegistry.cs
@@ -65,7 +65,7 @@ namespace Helsenorge.Registries
         public async Task<CommunicationPartyDetails> FindCommunicationPartyDetailsAsync(ILogger logger, int herId, bool forceUpdate)
         {
             var key = $"AR_FindCommunicationPartyDetailsAsync_{herId}";
-            var party = forceUpdate ? null : await CacheExtensions.ReadValueFromCache<CommunicationParty>(logger, _cache, key).ConfigureAwait(false);
+            var party = forceUpdate ? null : await CacheExtensions.ReadValueFromCache<CommunicationParty>(logger, _cache, key, _settings.CachingFormatter).ConfigureAwait(false);
 
             if (party == null)
             {
@@ -81,7 +81,7 @@ namespace Helsenorge.Registries
                         Data = { { "HerId", herId } }
                     };
                 }
-                await CacheExtensions.WriteValueToCache(logger, _cache, key, party, _settings.CachingInterval).ConfigureAwait(false);
+                await CacheExtensions.WriteValueToCache(logger, _cache, key, party, _settings.CachingInterval, _settings.CachingFormatter).ConfigureAwait(false);
             }
             return party == null ? default(CommunicationPartyDetails) : MapCommunicationPartyDetails(party);
         }
@@ -107,7 +107,7 @@ namespace Helsenorge.Registries
         public async Task<Abstractions.CertificateDetails> GetCertificateDetailsForEncryptionAsync(ILogger logger, int herId, bool forceUpdate)
         {
             var key = $"AR_GetCertificateDetailsForEncryption{herId}";
-            var certificateDetails = forceUpdate ? null : await CacheExtensions.ReadValueFromCache<AddressService.CertificateDetails>(logger, _cache, key).ConfigureAwait(false);
+            var certificateDetails = forceUpdate ? null : await CacheExtensions.ReadValueFromCache<AddressService.CertificateDetails>(logger, _cache, key, _settings.CachingFormatter).ConfigureAwait(false);
 
             if(certificateDetails == null)
             {
@@ -123,7 +123,7 @@ namespace Helsenorge.Registries
                         Data = { { "HerId", herId } }
                     };
                 }
-                await CacheExtensions.WriteValueToCache(logger, _cache, key, certificateDetails, _settings.CachingInterval).ConfigureAwait(false);
+                await CacheExtensions.WriteValueToCache(logger, _cache, key, certificateDetails, _settings.CachingInterval, _settings.CachingFormatter).ConfigureAwait(false);
             }
             return certificateDetails == null ? default(Abstractions.CertificateDetails) : MapCertificateDetails(herId, certificateDetails);
         }
@@ -149,7 +149,7 @@ namespace Helsenorge.Registries
         public async Task<Abstractions.CertificateDetails> GetCertificateDetailsForValidatingSignatureAsync(ILogger logger, int herId, bool forceUpdate)
         {
             var key = $"AR_GetCertificateDetailsForValidationSignature{herId}";
-            var certificateDetails = forceUpdate ? null : await CacheExtensions.ReadValueFromCache<AddressService.CertificateDetails>(logger, _cache, key).ConfigureAwait(false);
+            var certificateDetails = forceUpdate ? null : await CacheExtensions.ReadValueFromCache<AddressService.CertificateDetails>(logger, _cache, key, _settings.CachingFormatter).ConfigureAwait(false);
 
             if (certificateDetails == null)
             {
@@ -165,7 +165,7 @@ namespace Helsenorge.Registries
                         Data = { { "HerId", herId } }
                     };
                 }
-                await CacheExtensions.WriteValueToCache(logger, _cache, key, certificateDetails, _settings.CachingInterval).ConfigureAwait(false);
+                await CacheExtensions.WriteValueToCache(logger, _cache, key, certificateDetails, _settings.CachingInterval, _settings.CachingFormatter).ConfigureAwait(false);
             }
             return certificateDetails == null ? default(Abstractions.CertificateDetails) : MapCertificateDetails(herId, certificateDetails);
         }

--- a/src/Helsenorge.Registries/AddressRegistrySettings.cs
+++ b/src/Helsenorge.Registries/AddressRegistrySettings.cs
@@ -20,9 +20,16 @@ namespace Helsenorge.Registries
         /// The configuration containing WCF settings
         /// </summary>
         public WcfConfiguration WcfConfiguration { get; set; }
+
         /// <summary>
         /// The amount of time values should be cached
         /// </summary>
         public TimeSpan CachingInterval { get; set; } = new TimeSpan(1, 0, 0);
+
+        /// <summary>
+        /// Gets or sets the type of formatter to use when caching.
+        /// </summary>
+        public Utilities.CacheFormatterType CachingFormatter { get; set; } =
+            Utilities.CacheFormatterType.BinaryFormatter;
     }
 }

--- a/src/Helsenorge.Registries/CollaborationProtocolRegistry.cs
+++ b/src/Helsenorge.Registries/CollaborationProtocolRegistry.cs
@@ -81,7 +81,7 @@ namespace Helsenorge.Registries
             logger.LogDebug($"FindProtocolForCounterpartyAsync {counterpartyHerId}");
 
             var key = $"CPA_FindProtocolForCounterpartyAsync_{counterpartyHerId}";
-            var result = await CacheExtensions.ReadValueFromCache<CollaborationProtocolProfile>(logger, _cache, key).ConfigureAwait(false);
+            var result = await CacheExtensions.ReadValueFromCache<CollaborationProtocolProfile>(logger, _cache, key, _settings.CachingFormatter).ConfigureAwait(false);
             var xmlString = string.Empty;
 
             if (result != null)
@@ -124,7 +124,7 @@ namespace Helsenorge.Registries
                 result = doc.Root == null ? null : MapFrompartyInfo(doc.Root.Element(_ns + "PartyInfo"));
             }
 
-            await CacheExtensions.WriteValueToCache(logger, _cache, key, result, _settings.CachingInterval).ConfigureAwait(false);
+            await CacheExtensions.WriteValueToCache(logger, _cache, key, result, _settings.CachingInterval, _settings.CachingFormatter).ConfigureAwait(false);
             return result;
         }
 
@@ -161,7 +161,7 @@ namespace Helsenorge.Registries
             logger.LogDebug($"FindAgreementByIdAsync {id}");
 
             var key = $"CPA_FindAgreementByIdAsync_{id}";
-            var result = forceUpdate ? null : await CacheExtensions.ReadValueFromCache<CollaborationProtocolProfile>(logger, _cache, key).ConfigureAwait(false);
+            var result = forceUpdate ? null : await CacheExtensions.ReadValueFromCache<CollaborationProtocolProfile>(logger, _cache, key, _settings.CachingFormatter).ConfigureAwait(false);
 
             if (result != null)
             {
@@ -201,7 +201,7 @@ namespace Helsenorge.Registries
             result = MapFrompartyInfo(node);
             result.CpaId = id;
 
-            await CacheExtensions.WriteValueToCache(logger, _cache, key, result, _settings.CachingInterval).ConfigureAwait(false);
+            await CacheExtensions.WriteValueToCache(logger, _cache, key, result, _settings.CachingInterval, _settings.CachingFormatter).ConfigureAwait(false);
             return result;
         }
 
@@ -237,7 +237,7 @@ namespace Helsenorge.Registries
         {
 
             var key = $"CPA_FindAgreementForCounterpartyAsync_{_settings.MyHerId}_{counterpartyHerId}";
-            var result = forceUpdate ? null : await CacheExtensions.ReadValueFromCache<CollaborationProtocolProfile>(logger, _cache, key).ConfigureAwait(false);
+            var result = forceUpdate ? null : await CacheExtensions.ReadValueFromCache<CollaborationProtocolProfile>(logger, _cache, key, _settings.CachingFormatter).ConfigureAwait(false);
 
             if (result != null)
             {
@@ -275,7 +275,7 @@ namespace Helsenorge.Registries
             result = MapFrompartyInfo(node);
             result.CpaId = Guid.Parse(doc.Root.Attribute(_ns + "cpaid").Value);
             
-            await CacheExtensions.WriteValueToCache(logger, _cache, key, result, _settings.CachingInterval).ConfigureAwait(false);
+            await CacheExtensions.WriteValueToCache(logger, _cache, key, result, _settings.CachingInterval, _settings.CachingFormatter).ConfigureAwait(false);
             return result;
         }
 

--- a/src/Helsenorge.Registries/CollaborationProtocolRegistrySettings.cs
+++ b/src/Helsenorge.Registries/CollaborationProtocolRegistrySettings.cs
@@ -20,14 +20,23 @@ namespace Helsenorge.Registries
         /// The configuration containing WCF settings
         /// </summary>
         public WcfConfiguration WcfConfiguration { get; set; }
+
         /// <summary>
         /// The amount of time values should be cached
         /// </summary>
         public TimeSpan CachingInterval { get; set; } = new TimeSpan(1, 0, 0);
+
+        /// <summary>
+        /// Gets or sets the type of formatter to use when caching.
+        /// </summary>
+        public Utilities.CacheFormatterType CachingFormatter { get; set; } =
+            Utilities.CacheFormatterType.BinaryFormatter;
+
         /// <summary>
         /// The HerId that belongs to me. In CPA operations, two communication parties may be returned, need to know which one is us
         /// </summary>
         public int MyHerId { get; set; }
+
         /// <summary>
         /// Use online certificate revocation list (CRL) check. Default true.
         /// </summary>

--- a/src/Helsenorge.Registries/Utilities/CacheFormatterType.cs
+++ b/src/Helsenorge.Registries/Utilities/CacheFormatterType.cs
@@ -1,0 +1,26 @@
+/* 
+ * Copyright (c) 2020, Norsk Helsenett SF and contributors
+ * See the file CONTRIBUTORS for details.
+ * 
+ * This file is licensed under the MIT license
+ * available at https://raw.githubusercontent.com/helsenorge/Helsenorge.Messaging/master/LICENSE
+ */
+
+namespace Helsenorge.Registries.Utilities
+{
+    /// <summary>
+    /// Enumerates how to serialize/deserialize items when caching.
+    /// </summary>
+    public enum CacheFormatterType
+    {
+        /// <summary>
+        /// Use the <see cref="System.Runtime.Serialization.Formatters.Binary.BinaryFormatter"/> formatter.
+        /// </summary>
+        BinaryFormatter,
+
+        /// <summary>
+        /// Use <see cref="System.Xml.Serialization.XmlSerializer"/>.
+        /// </summary>
+        XmlFormatter,
+    }
+}

--- a/src/Helsenorge.Registries/Utilities/XmlCacheFormatter.cs
+++ b/src/Helsenorge.Registries/Utilities/XmlCacheFormatter.cs
@@ -1,0 +1,45 @@
+﻿/* 
+ * Copyright (c) 2020, Norsk Helsenett SF and contributors
+ * See the file CONTRIBUTORS for details.
+ * 
+ * This file is licensed under the MIT license
+ * available at https://raw.githubusercontent.com/helsenorge/Helsenorge.Messaging/master/LICENSE
+ */
+
+using System.IO;
+using System.Runtime.Serialization;
+using System.Text;
+using System.Threading.Tasks;
+using System.Xml;
+
+namespace Helsenorge.Registries.Utilities
+{
+    internal static class XmlCacheFormatter
+    {
+        public static byte[] Serialize<T>(T value)
+            where T : class
+        {
+            var serializer = new DataContractSerializer(typeof(T));
+            using var stream = new MemoryStream();
+            var settings = new XmlWriterSettings
+            {
+                Encoding = Encoding.UTF8,
+            };
+
+            using var writer = XmlWriter.Create(stream, settings);
+            serializer.WriteObject(writer, value);
+            writer.Close();
+            stream.Seek(0, SeekOrigin.Begin);
+            return stream.ToArray();
+        }
+
+        public static async Task<T> DeserializeAsync<T>(byte[] value)
+            where T : class
+        {
+            using var stream = new MemoryStream(value);
+            using var reader = new StreamReader(stream, Encoding.UTF8);
+            var serializer = new DataContractSerializer(typeof(T));
+            return await Task.FromResult(serializer.ReadObject(stream) as T);
+        }
+    }
+}

--- a/src/Helsenorge.Registries/Utilities/XmlCacheFormatter.cs
+++ b/src/Helsenorge.Registries/Utilities/XmlCacheFormatter.cs
@@ -16,10 +16,9 @@ namespace Helsenorge.Registries.Utilities
 {
     internal static class XmlCacheFormatter
     {
-        public static byte[] Serialize<T>(T value)
-            where T : class
+        public static byte[] Serialize(object value)
         {
-            var serializer = new DataContractSerializer(typeof(T));
+            var serializer = new DataContractSerializer(value.GetType());
             using var stream = new MemoryStream();
             var settings = new XmlWriterSettings
             {

--- a/test/Helsenorge.Registries.Tests/CollaborationRegistryTests.cs
+++ b/test/Helsenorge.Registries.Tests/CollaborationRegistryTests.cs
@@ -6,16 +6,17 @@
  * available at https://raw.githubusercontent.com/helsenorge/Helsenorge.Messaging/master/LICENSE
  */
 
-using Helsenorge.Registries.Abstractions;
-using Helsenorge.Registries.Configuration;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.IO;
 using System.Linq;
 using System.ServiceModel;
+using Helsenorge.Registries.Abstractions;
+using Helsenorge.Registries.Configuration;
 using Helsenorge.Registries.Tests.Mocks;
+using Helsenorge.Registries.Utilities;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Helsenorge.Registries.Tests
 {
@@ -368,5 +369,16 @@ namespace Helsenorge.Registries.Tests
             Assert.IsNotNull(profile.EncryptionCertificate);
             Assert.IsTrue(profile.FindMessagePartsForReceiveMessage("DIALOG_INNBYGGER_TEST").Any());
         }
+
+        [TestMethod]
+        public void Serialize_CollaborationProtocolProfile()
+        {
+            var profile = _registry.FindProtocolForCounterpartyAsync(_logger, 93238).Result;
+            var serialized = XmlCacheFormatter.Serialize(profile);
+            var deserialized = XmlCacheFormatter.DeserializeAsync<CollaborationProtocolProfile>(serialized).Result;
+            Assert.AreEqual(profile.CpaId, profile.CpaId);
+            Assert.AreEqual(profile.EncryptionCertificate.Thumbprint, deserialized.EncryptionCertificate.Thumbprint);
+        }
+
     }
 }


### PR DESCRIPTION
The existing serialization code when caching AR information uses `BinaryFormatter`, wich is [discouraged](https://docs.microsoft.com/en-us/dotnet/core/compatibility/core-libraries/5.0/binaryformatter-serialization-obsolete) by Microsoft.

This change provides a backwards-compatible alternative, using `DataContractSerializer` instead.

To use the new formatter, set `AddressRegistrySettings.CachingFormatter` and `CollaborationProtocolRegistrySettings.CachingFormatter` to `CacheFormatter.XmlFormatter`, instead of the default value which is `CacheFormatter.BinaryFormatter`.