### PR TITLE
Registries: Cert serialization working on linux

### DIFF
--- a/src/Helsenorge.Registries/Abstractions/CollaborationProtocolProfile.cs
+++ b/src/Helsenorge.Registries/Abstractions/CollaborationProtocolProfile.cs
@@ -42,10 +42,10 @@ namespace Helsenorge.Registries.Abstractions
         {
             _encryptionCertificateBase64String = EncryptionCertificate == null 
                 ? null 
-                : Convert.ToBase64String(EncryptionCertificate.Export(X509ContentType.SerializedCert));
+                : Convert.ToBase64String(EncryptionCertificate.Export(X509ContentType.Cert));
             _signatureCertificateBase64String = SignatureCertificate == null 
                 ? null 
-                : Convert.ToBase64String(SignatureCertificate.Export(X509ContentType.SerializedCert));
+                : Convert.ToBase64String(SignatureCertificate.Export(X509ContentType.Cert));
         }
 
         /// <summary>


### PR DESCRIPTION
When serializing X509 certificates, using `.Export(X509ContentType.SerializedCert)` causes an exception in Linux:

> System.PlatformNotSupportedException: X509ContentType.SerializedCert and X509ContentType.SerializedStore are not supported on Unix

`X509ContentType.SerializedCert` causes the cert library to use Windows native functions to serialize the certificate, presumably to preserve encoded properties in Windows Certificate Store. If only the public key is required, this shouldn't be necessary, and `X509ContentType.Cert` can be used instead.

More information: https://docs.microsoft.com/en-us/dotnet/api/system.security.cryptography.x509certificates.x509contenttype?view=net-6.0