### PR TITLE
Registries: Cache mapped instead of SOAP AR values

### DIFF
--- a/src/Helsenorge.Registries/AddressRegistry.cs
+++ b/src/Helsenorge.Registries/AddressRegistry.cs
@@ -175,7 +175,14 @@ namespace Helsenorge.Registries
                             Data = { { "HerId", herId } }
                         };
                     }
-                    await CacheExtensions.WriteValueToCache(logger, _cache, key, details, _settings.CachingInterval, _settings.CachingFormatter).ConfigureAwait(false);
+
+                    await CacheExtensions.WriteValueToCache(
+                        logger,
+                        _cache,
+                        key,
+                        details,
+                        _settings.CachingInterval,
+                        _settings.CachingFormatter).ConfigureAwait(false);
                 }
 
                 return details;

--- a/src/Helsenorge.Registries/AddressRegistry.cs
+++ b/src/Helsenorge.Registries/AddressRegistry.cs
@@ -259,7 +259,13 @@ namespace Helsenorge.Registries
                         };
                     }
 
-                    await CacheExtensions.WriteValueToCache(logger, _cache, key, details, _settings.CachingInterval, _settings.CachingFormatter).ConfigureAwait(false);
+                    await CacheExtensions.WriteValueToCache(
+                        logger,
+                        _cache,
+                        key,
+                        details,
+                        _settings.CachingInterval,
+                        _settings.CachingFormatter).ConfigureAwait(false);
                 }
 
                 return details;

--- a/src/Helsenorge.Registries/AddressRegistry.cs
+++ b/src/Helsenorge.Registries/AddressRegistry.cs
@@ -65,6 +65,46 @@ namespace Helsenorge.Registries
         public async Task<CommunicationPartyDetails> FindCommunicationPartyDetailsAsync(ILogger logger, int herId, bool forceUpdate)
         {
             var key = $"AR_FindCommunicationPartyDetailsAsync_{herId}";
+
+            // FIXME: Next major release, the code inside this clause should be used with both formatter types.
+            if (this._settings.CachingFormatter == CacheFormatterType.XmlFormatter)
+            {
+                var partyDetails = forceUpdate
+                    ? null
+                    : await CacheExtensions.ReadValueFromCache<CommunicationPartyDetails>(
+                        logger,
+                        _cache,
+                        key,
+                        _settings.CachingFormatter).ConfigureAwait(false);
+
+                if (partyDetails == null)
+                {
+                    try
+                    {
+                        var registryData = await FindCommunicationPartyDetails(logger, herId).ConfigureAwait(false);
+                        partyDetails = MapCommunicationPartyDetails(registryData);
+                    }
+                    catch (FaultException ex)
+                    {
+                        throw new RegistriesException(ex.Message, ex)
+                        {
+                            EventId = EventIds.CommunicationPartyDetails,
+                            Data = { { "HerId", herId } }
+                        };
+                    }
+
+                    await CacheExtensions.WriteValueToCache(
+                        logger,
+                        _cache,
+                        key,
+                        partyDetails,
+                        _settings.CachingInterval,
+                        _settings.CachingFormatter).ConfigureAwait(false);
+                }
+
+                return partyDetails ?? default(CommunicationPartyDetails);
+            }
+
             var party = forceUpdate ? null : await CacheExtensions.ReadValueFromCache<CommunicationParty>(logger, _cache, key, _settings.CachingFormatter).ConfigureAwait(false);
 
             if (party == null)
@@ -107,6 +147,40 @@ namespace Helsenorge.Registries
         public async Task<Abstractions.CertificateDetails> GetCertificateDetailsForEncryptionAsync(ILogger logger, int herId, bool forceUpdate)
         {
             var key = $"AR_GetCertificateDetailsForEncryption{herId}";
+
+            // FIXME: Next major release, the code inside this clause should be used with both formatter types.
+            if (this._settings.CachingFormatter == CacheFormatterType.XmlFormatter)
+            {
+                var details = forceUpdate
+                    ? null
+                    : await CacheExtensions.ReadValueFromCache<Abstractions.CertificateDetails>(
+                        logger,
+                        _cache,
+                        key,
+                        _settings.CachingFormatter).ConfigureAwait(false);
+
+                if (details == null)
+                {
+                    try
+                    {
+                        var registryData = await GetCertificateDetailsForEncryptionInternal(logger, herId)
+                            .ConfigureAwait(false);
+                        details = MapCertificateDetails(herId, registryData);
+                    }
+                    catch (FaultException ex)
+                    {
+                        throw new RegistriesException(ex.Message, ex)
+                        {
+                            EventId = EventIds.CerificateDetails,
+                            Data = { { "HerId", herId } }
+                        };
+                    }
+                    await CacheExtensions.WriteValueToCache(logger, _cache, key, details, _settings.CachingInterval, _settings.CachingFormatter).ConfigureAwait(false);
+                }
+
+                return details;
+            }
+
             var certificateDetails = forceUpdate ? null : await CacheExtensions.ReadValueFromCache<AddressService.CertificateDetails>(logger, _cache, key, _settings.CachingFormatter).ConfigureAwait(false);
 
             if(certificateDetails == null)
@@ -149,6 +223,41 @@ namespace Helsenorge.Registries
         public async Task<Abstractions.CertificateDetails> GetCertificateDetailsForValidatingSignatureAsync(ILogger logger, int herId, bool forceUpdate)
         {
             var key = $"AR_GetCertificateDetailsForValidationSignature{herId}";
+
+            // FIXME: Next major release, the code inside this clause should be used with both formatter types.
+            if (this._settings.CachingFormatter == CacheFormatterType.XmlFormatter)
+            {
+                var details = forceUpdate
+                    ? null
+                    : await CacheExtensions.ReadValueFromCache<Abstractions.CertificateDetails>(
+                        logger,
+                        _cache,
+                        key,
+                        _settings.CachingFormatter).ConfigureAwait(false);
+
+                if (details == null)
+                {
+                    try
+                    {
+                        var registryData = await GetCertificateDetailsForValidatingSignatureInternal(logger, herId)
+                            .ConfigureAwait(false);
+                        details = MapCertificateDetails(herId, registryData);
+                    }
+                    catch (FaultException ex)
+                    {
+                        throw new RegistriesException(ex.Message, ex)
+                        {
+                            EventId = EventIds.CerificateDetails,
+                            Data = { { "HerId", herId } }
+                        };
+                    }
+
+                    await CacheExtensions.WriteValueToCache(logger, _cache, key, details, _settings.CachingInterval, _settings.CachingFormatter).ConfigureAwait(false);
+                }
+
+                return details;
+            }
+
             var certificateDetails = forceUpdate ? null : await CacheExtensions.ReadValueFromCache<AddressService.CertificateDetails>(logger, _cache, key, _settings.CachingFormatter).ConfigureAwait(false);
 
             if (certificateDetails == null)

--- a/test/Helsenorge.Registries.Tests/AddressRegistryTests.cs
+++ b/test/Helsenorge.Registries.Tests/AddressRegistryTests.cs
@@ -219,6 +219,32 @@ namespace Helsenorge.Registries.Tests
         }
 
         [TestMethod]
+        public void Serialize_AddressService_CommunicationPartyDetails()
+        {
+            var item = new Abstractions.CommunicationPartyDetails
+            {
+                Name = "Name",
+                HerId = 1234,
+                ParentHerId = 4321,
+                ParentName = "Parent Name",
+                SynchronousQueueName = "1234_sync",
+                AsynchronousQueueName = "1234_async",
+                ErrorQueueName = "1234_error",
+            };
+
+            var serialized = XmlCacheFormatter.Serialize(item);
+            var deserialized =
+                XmlCacheFormatter.DeserializeAsync<Abstractions.CommunicationPartyDetails>(serialized).Result;
+            Assert.AreEqual(item.Name, deserialized.Name);
+            Assert.AreEqual(item.HerId, deserialized.HerId);
+            Assert.AreEqual(item.ParentHerId, deserialized.ParentHerId);
+            Assert.AreEqual(item.ParentName, deserialized.ParentName);
+            Assert.AreEqual(item.SynchronousQueueName, deserialized.SynchronousQueueName);
+            Assert.AreEqual(item.AsynchronousQueueName, deserialized.AsynchronousQueueName);
+            Assert.AreEqual(item.ErrorQueueName, deserialized.ErrorQueueName);
+        }
+
+        [TestMethod]
         public void Serialize_AddressService_CertificateDetails()
         {
             var keys = ECDsa.Create();


### PR DESCRIPTION
The responses from the AddressRegistry SOAP requests are cached rather than their abstracted counterparts used in the calling code. Because of this, information that is never used is put into the cache. In one case, this also causes problems with the recently added `XmlCacheFormatter` formatter, because `DataContractSerializer` doesn't understand how to deserialize the objects.

The proposed solution is to map the responses before adding them to the cache. This breaks existing cache records, so the change cannot be done universally within a minor release. Because of this, the change will only affect setups using the `XmlCacheFormatter` for now.