### PR TITLE
ServiceBus: Set correct ReplyTo value

### DIFF
--- a/src/Helsenorge.Messaging/ServiceBus/ServiceBusCore.cs
+++ b/src/Helsenorge.Messaging/ServiceBus/ServiceBusCore.cs
@@ -217,7 +217,10 @@ namespace Helsenorge.Messaging.ServiceBus
             logger.LogAfterFactoryPoolCreateMessage(outgoingMessage.MessageFunction, Core.Settings.MyHerId, outgoingMessage.ToHerId, outgoingMessage.MessageId);
 
             if (queueType != QueueType.SynchronousReply)
-                messagingMessage.ReplyTo = replyTo ?? queueName;
+            {
+                messagingMessage.ReplyTo =
+                    replyTo ?? await ConstructQueueName(logger, Core.Settings.MyHerId, queueType).ConfigureAwait(false);
+            }
             messagingMessage.ContentType = Core.MessageProtection.ContentType;
             messagingMessage.MessageId = outgoingMessage.MessageId;
             messagingMessage.To = queueName;


### PR DESCRIPTION
This fixes a bug where we would set the queue name of the receiver as our ReplyTo value.