### PR TITLE
Registries: Mapping changes for abstractions

### DIFF
--- a/src/Helsenorge.Registries/Abstractions/CollaborationProtocolMessage.cs
+++ b/src/Helsenorge.Registries/Abstractions/CollaborationProtocolMessage.cs
@@ -33,9 +33,13 @@ namespace Helsenorge.Registries.Abstractions
     public class CollaborationProtocolMessage
     {
         /// <summary>
-        /// Name of message. i.e. DIALOG_INNBYGGER_KOORDINATOR
+        /// Name of message function. i.e. DIALOG_INNBYGGER_KOORDINATOR
         /// </summary>
         public string Name { get; set; }
+        /// <summary>
+        /// Name of action. i.e. SvarLedigeTimer or APPREC
+        /// </summary>
+        public string Action { get; set; }
         /// <summary>
         /// The delivery channel that should be used. This will be the full queue name
         /// </summary>

--- a/src/Helsenorge.Registries/Abstractions/CollaborationProtocolProfile.cs
+++ b/src/Helsenorge.Registries/Abstractions/CollaborationProtocolProfile.cs
@@ -160,7 +160,7 @@ namespace Helsenorge.Registries.Abstractions
 
             if (messages == null)
             {
-                return Roles.SelectMany(role => role.SendMessages).FirstOrDefault((m) => m.Name.Equals(messageName, StringComparison.Ordinal));
+                return Roles.SelectMany(role => role.SendMessages).FirstOrDefault((m) => m.Action.Equals(messageName, StringComparison.Ordinal));
             }
             else
             {
@@ -182,7 +182,7 @@ namespace Helsenorge.Registries.Abstractions
 
             if (messages == null)
             {
-                return Roles.SelectMany(role => role.ReceiveMessages).FirstOrDefault((m) => m.Name.Equals(messageName, StringComparison.Ordinal));
+                return Roles.SelectMany(role => role.ReceiveMessages).FirstOrDefault((m) => m.Action.Equals(messageName, StringComparison.Ordinal));
             }
             else
             {
@@ -192,22 +192,19 @@ namespace Helsenorge.Registries.Abstractions
 
         private IEnumerable<CollaborationProtocolMessagePart> FindMessagePartsForSenderOrReceiverAppRec(string messageName, Func<CollaborationProtocolRole, IList<CollaborationProtocolMessage>> sendOrReceive)
         {
-            foreach (var role in Roles)
-            {
-                var messages = sendOrReceive(role);
+            // first find the role with the correct message
+            var role = Roles.FirstOrDefault(r => r.ProcessSpecification.Name.Equals(messageName, StringComparison.OrdinalIgnoreCase));
+            if (role == null)
+                return null;
 
-                var message = messages.FirstOrDefault((m) => m.Name.Equals(messageName, StringComparison.OrdinalIgnoreCase));
-                // first find the role with the correct message
-                if (message == null) continue;
-                
-                // then we find the Apprec message in the same role
-                message = messages.FirstOrDefault((m) => m.Name.Equals("APPREC", StringComparison.OrdinalIgnoreCase));
-                if (message != null)
-                {
-                    return message.Parts;
-                }
-            }
-            return null;
+            var messages = sendOrReceive(role);
+
+            // then we find the Apprec message in the same role
+            var message = messages.FirstOrDefault((m) => m.Action.Equals("APPREC", StringComparison.OrdinalIgnoreCase));
+            if (message == null)
+                return null;
+
+            return message.Parts;
         }
     }
 }

--- a/src/Helsenorge.Registries/CollaborationProtocolRegistry.cs
+++ b/src/Helsenorge.Registries/CollaborationProtocolRegistry.cs
@@ -443,11 +443,11 @@ namespace Helsenorge.Registries
 
             foreach (var item in serviceBinding.Elements(_ns + "CanSend"))
             {
-                role.SendMessages.Add(CreateFromThisPartyActionBinding(item.Element(_ns + "ThisPartyActionBinding"), partyInfo));
+                role.SendMessages.Add(CreateFromThisPartyActionBinding(item.Element(_ns + "ThisPartyActionBinding"), partyInfo, processSpecification.Name));
             }
             foreach (var item in serviceBinding.Elements(_ns + "CanReceive"))
             {
-                role.ReceiveMessages.Add(CreateFromThisPartyActionBinding(item.Element(_ns + "ThisPartyActionBinding"), partyInfo));
+                role.ReceiveMessages.Add(CreateFromThisPartyActionBinding(item.Element(_ns + "ThisPartyActionBinding"), partyInfo, processSpecification.Name));
             }
             return role;
         }
@@ -465,7 +465,7 @@ namespace Helsenorge.Registries
         ///		</tns:ThisPartyActionBinding>
         /// ]]>
         /// </example>
-        private CollaborationProtocolMessage CreateFromThisPartyActionBinding(XElement thisPartyActionBinding, XContainer partyInfo)
+        private CollaborationProtocolMessage CreateFromThisPartyActionBinding(XElement thisPartyActionBinding, XContainer partyInfo, string messageFunction)
         {
             if (thisPartyActionBinding == null) throw new ArgumentNullException(nameof(thisPartyActionBinding));
             if (partyInfo == null) throw new ArgumentNullException(nameof(partyInfo));
@@ -505,7 +505,8 @@ namespace Helsenorge.Registries
 
             var message = new CollaborationProtocolMessage
             {
-                Name = thisPartyActionBinding.Attribute(_ns + "action").Value,
+                Name = messageFunction.ToUpper(),
+                Action = thisPartyActionBinding.Attribute(_ns + "action").Value,
                 DeliveryChannel = transportReceiverNode.Element(_ns + "Endpoint")?.Attribute(_ns + "uri")?.Value,
                 DeliveryProtocol = ParseDeliveryProtocol(transportReceiverNode.Element(_ns + "TransportProtocol")?.Value),
                 Parts = FindMessageParts(packageId, partyInfo)

--- a/test/Helsenorge.Registries.Tests/CollaborationRegistryTests.cs
+++ b/test/Helsenorge.Registries.Tests/CollaborationRegistryTests.cs
@@ -104,7 +104,7 @@ namespace Helsenorge.Registries.Tests
         }
 
         [TestMethod]
-        public void Read_CollaborationProfile()
+        public void Read_CollaborationProfile_OldCPPA()
         {
             var profile = _registry.FindProtocolForCounterpartyAsync(_logger, 93238).Result;
             Assert.AreEqual(profile.CpaId, Guid.Empty);
@@ -124,6 +124,8 @@ namespace Helsenorge.Registries.Tests
             Assert.AreEqual(2, role.SendMessages.Count);
             var message = role.ReceiveMessages[0];
             Assert.AreEqual("DIALOG_INNBYGGER_DIGITALBRUKER", message.Name);
+            // This test uses old CPPA XML (Service) where Action name is the MessageFunction
+            Assert.AreEqual("DIALOG_INNBYGGER_DIGITALBRUKER", message.Action); 
             Assert.AreEqual("sb.test.nhn.no/DigitalDialog/93238_async", message.DeliveryChannel);
             Assert.AreEqual(DeliveryProtocol.Amqp, message.DeliveryProtocol);
 
@@ -222,12 +224,13 @@ namespace Helsenorge.Registries.Tests
             Assert.IsNotNull(profile.FindMessageForSender("APPREC"));
         }
         [TestMethod]
-        public void FindMessageForSender_Found_Ny_CPP()
+        public void FindMessageForSender_Found_Ny_CPPA()
         {
             var profile = _registry.FindProtocolForCounterpartyAsync(_logger, 93238).Result;
             var collaborationProtocolMessage = profile.FindMessageForReceiver("DIALOG_INNBYGGER_BEHANDLEROVERSIKT");
             Assert.IsNotNull(collaborationProtocolMessage);
-            Assert.AreEqual("Svar", collaborationProtocolMessage.Name);
+            Assert.AreEqual("DIALOG_INNBYGGER_BEHANDLEROVERSIKT", collaborationProtocolMessage.Name);
+            Assert.AreEqual("Svar", collaborationProtocolMessage.Action);
         }
         [TestMethod]
         public void FindMessageForSender_NotFound()
@@ -255,12 +258,13 @@ namespace Helsenorge.Registries.Tests
             Assert.IsNotNull(profile.FindMessageForReceiver("APPREC"));
         }
         [TestMethod]
-        public void FindMessageForReceiver_Found_Ny_CPP()
+        public void FindMessageForReceiver_Found_Ny_CPPA()
         {
             var profile = _registry.FindProtocolForCounterpartyAsync(_logger, 93238).Result;
             var collaborationProtocolMessage = profile.FindMessageForSender("DIALOG_INNBYGGER_BEHANDLEROVERSIKT");
             Assert.IsNotNull(collaborationProtocolMessage);
-            Assert.AreEqual("Hent", collaborationProtocolMessage.Name);
+            Assert.AreEqual("DIALOG_INNBYGGER_BEHANDLEROVERSIKT", collaborationProtocolMessage.Name);
+            Assert.AreEqual("Hent", collaborationProtocolMessage.Action);
         }
         [TestMethod]
         public void FindMessageForReceiver_NotFound()


### PR DESCRIPTION
ThisPartyActionBinding:action maps to new property CollaborationProtocolMessage.Action.

CollaborationProtocolMessage.Name is now mapped from ProcessSpecification:name.

These changes are backward compatible.

This commit fixes the issue #395 