### PR TITLE
Registries: Add DeliveryChannel to DummyCollaborationProtocolProfile

### DIFF
--- a/src/Helsenorge.Registries/CollaborationProtocolRegistry.cs
+++ b/src/Helsenorge.Registries/CollaborationProtocolRegistry.cs
@@ -114,9 +114,14 @@ namespace Helsenorge.Registries
             }
             if (string.IsNullOrEmpty(xmlString))
             {
+                // HACK: This whole thing is a hack and should be removed.
+                var communicationParty = await _adressRegistry.FindCommunicationPartyDetailsAsync(logger, counterpartyHerId).ConfigureAwait(false);
+                // HACK: We are assuming that we should return the asynchronous queue name as the delivery channel.
+                var deliveryChannel = communicationParty.AsynchronousQueueName;
                 result = CreateDummyCollaborationProtocolProfile(counterpartyHerId,
                     await _adressRegistry.GetCertificateDetailsForEncryptionAsync(logger, counterpartyHerId).ConfigureAwait(false),
-                    await _adressRegistry.GetCertificateDetailsForValidatingSignatureAsync(logger, counterpartyHerId).ConfigureAwait(false));
+                    await _adressRegistry.GetCertificateDetailsForValidatingSignatureAsync(logger, counterpartyHerId).ConfigureAwait(false),
+                    deliveryChannel);
             }
             else
             {
@@ -342,11 +347,35 @@ namespace Helsenorge.Registries
         protected virtual Task<string> GetCollaborationProtocolProfileAsXmlAsyncInternal(ILogger logger, Guid id)
             => Invoke(logger, x => x.GetCppXmlAsync(id), "GetCppXmlAsync");
         
-        private CollaborationProtocolProfile CreateDummyCollaborationProtocolProfile(int herId, Abstractions.CertificateDetails encryptionCertificate, Abstractions.CertificateDetails signatureCertificate)
+        // HACK: This is a hack used for when interns and substitues which do not have CPP send a message on behalf of the GP.
+        private CollaborationProtocolProfile CreateDummyCollaborationProtocolProfile(int herId, Abstractions.CertificateDetails encryptionCertificate, Abstractions.CertificateDetails signatureCertificate, string deliveryChannel)
         {
             return new CollaborationProtocolProfile
             {
-                Roles = new List<CollaborationProtocolRole>(),
+                Roles = new List<CollaborationProtocolRole>
+                {
+                    new CollaborationProtocolRole
+                    {
+                        ReceiveMessages = new List<CollaborationProtocolMessage>
+                        {
+                            new CollaborationProtocolMessage
+                            {
+                                Name = "APPREC",
+                                DeliveryProtocol = DeliveryProtocol.Amqp,
+                                DeliveryChannel = deliveryChannel
+                            }
+                        },
+                        SendMessages = new List<CollaborationProtocolMessage>
+                        {
+                            new CollaborationProtocolMessage
+                            {
+                                Name = "APPREC",
+                                DeliveryProtocol = DeliveryProtocol.Amqp,
+                                DeliveryChannel = deliveryChannel
+                            }
+                        }
+                    }
+                },
                 HerId = herId,
                 Name = DummyPartyName,
                 EncryptionCertificate = encryptionCertificate?.Certificate,

--- a/test/Helsenorge.Registries.Tests/CollaborationRegistryTests.cs
+++ b/test/Helsenorge.Registries.Tests/CollaborationRegistryTests.cs
@@ -139,7 +139,7 @@ namespace Helsenorge.Registries.Tests
         [TestMethod]
         public void Read_CollaborationProfile_NotFound()
         {
-            var profile = _registry.FindProtocolForCounterpartyAsync(_logger, 1234).Result;
+            var profile = _registry.FindProtocolForCounterpartyAsync(_logger, 93252).Result;
             Assert.IsNotNull(profile);
             Assert.AreEqual("DummyCollaborationProtocolProfile", profile.Name);
         }


### PR DESCRIPTION
This adds an asynchronous DeliveryChannel to the Dummy instance of our CollaborationProtocolProfile.