### PR TITLE
Messaging: Add DeliveryChannel to Dummy Collaboration Protocol Agreement

### DIFF
--- a/src/Helsenorge.Messaging/MessagingClient.cs
+++ b/src/Helsenorge.Messaging/MessagingClient.cs
@@ -244,10 +244,15 @@ namespace Helsenorge.Messaging
             if ((profile != null && profile.Name == Registries.CollaborationProtocolRegistry.DummyPartyName)
                 || (collaborationProtocolMessage == null && messageFunction.ToUpper().Contains("DIALOG_INNBYGGER_TIMERESERVASJON")))
             {
+                // HACK: This whole section inside this if statement is a hack to support communication parties which do not have the process DIALOG_INNBYGGER_TIMERESERVASJON configured.
+                // FIXME: This hack is to be removed in the future and external parties should start to use DIALOG_INNBYGGER_AVTALEUSTENDING and DIALOG_INNBYGGER_AVTALEAVBESTILLING.
+                var communicationParty = await AddressRegistry.FindCommunicationPartyDetailsAsync(logger, message.ToHerId).ConfigureAwait(false);
+
                 collaborationProtocolMessage = new CollaborationProtocolMessage
                 {
                     Name = messageFunction,
                     DeliveryProtocol = DeliveryProtocol.Amqp,
+                    DeliveryChannel = communicationParty.AsynchronousQueueName,
                     Parts = new List<CollaborationProtocolMessagePart>
                     {
                         new CollaborationProtocolMessagePart


### PR DESCRIPTION
This is a fix to add the DeliveryChannel for the scenario where the external party is missing the communication process DIALOG_INNBYGGER_TIMERESERVASJON.