### PR TITLE
Registries: Do not parse VersionString if it's null or empty

### DIFF
--- a/src/Helsenorge.Registries/Abstractions/ProcessSpecification.cs
+++ b/src/Helsenorge.Registries/Abstractions/ProcessSpecification.cs
@@ -37,7 +37,7 @@ namespace Helsenorge.Registries.Abstractions
         {
             get
             {
-                if (_version == null)
+                if (_version == null && !string.IsNullOrWhiteSpace(VersionString))
                 {
                     _version = new Version(this.VersionString);
                 }

--- a/src/Helsenorge.Registries/Abstractions/ProcessSpecification.cs
+++ b/src/Helsenorge.Registries/Abstractions/ProcessSpecification.cs
@@ -21,7 +21,7 @@ namespace Helsenorge.Registries.Abstractions
     [Serializable]
     public class ProcessSpecification
     {
-        Version _version;
+        private Version _version;
         /// <summary>
         /// Name of process specification
         /// </summary>
@@ -39,7 +39,7 @@ namespace Helsenorge.Registries.Abstractions
             {
                 if (_version == null && !string.IsNullOrWhiteSpace(VersionString))
                 {
-                    _version = new Version(this.VersionString);
+                    _version = new Version(VersionString);
                 }
                 return _version;
             }


### PR DESCRIPTION
Avoid parsing VersionString if it's null, empty or only consists of whitespace.