### PR TITLE
ServiceBus: Add our own HER-id to the ResponseTime log statement

### DIFF
--- a/src/Helsenorge.Messaging/ServiceBus/Senders/SynchronousSender.cs
+++ b/src/Helsenorge.Messaging/ServiceBus/Senders/SynchronousSender.cs
@@ -147,7 +147,7 @@ namespace Helsenorge.Messaging.ServiceBus.Senders
                 logger.LogTimeoutError(message.MessageFunction, message.MessageId, message.ToHerId);
                 // logs the response time before throwing exception
                 stopwatch.Stop();
-                logger.LogResponseTime(message.MessageFunction, message.ToHerId, 0, message.MessageId, stopwatch.ElapsedMilliseconds.ToString());
+                logger.LogResponseTime(message.MessageFunction, message.ToHerId, _core.Settings.MyHerId, message.MessageId, stopwatch.ElapsedMilliseconds.ToString());
 
                 throw new MessagingException(error)
                 {


### PR DESCRIPTION
Instead of 0 log our own HER-id.