### PR TITLE
AdminLib+Examples+Tests: Add Helsenorge.Messaging.AdminLib

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,3 +27,4 @@ jobs:
       run: |
         dotnet test "./test/Helsenorge.Messaging.Tests/Helsenorge.Messaging.Tests.csproj"
         dotnet test "./test/Helsenorge.Registries.Tests/Helsenorge.Registries.Tests.csproj"
+        dotnet test "./test/Helsenorge.Messaging.AdminLib.Tests/Helsenorge.Messaging.AdminLib.Tests.csproj"

--- a/.github/workflows/nuget-deploy.yml
+++ b/.github/workflows/nuget-deploy.yml
@@ -21,6 +21,7 @@ jobs:
         run: |
           dotnet pack "./src/Helsenorge.Messaging/Helsenorge.Messaging.csproj" -c Release
           dotnet pack "./src/Helsenorge.Registries/Helsenorge.Registries.csproj" -c Release
+          dotnet pack "./src/Helsenorge.Messaging.AdminLib/Helsenorge.Messaging.AdminLib.csproj" -c Release
       - name: Deploy Nuget Packages
         run: dotnet nuget push .\src\**\*.nupkg
           --api-key ${{ secrets.NUGET_API_KEY }}

--- a/Examples/RepublishExample/Program.cs
+++ b/Examples/RepublishExample/Program.cs
@@ -1,0 +1,42 @@
+﻿/*
+ * Copyright (c) 2022, Norsk Helsenett SF and contributors
+ * See the file CONTRIBUTORS for details.
+ *
+ * This file is licensed under the MIT license
+ * available at https://raw.githubusercontent.com/helsenorge/Helsenorge.Messaging/master/LICENSE
+ */
+
+using Helsenorge.Messaging.AdminLib;
+using Helsenorge.Messaging.AdminLib.RabbitMQ;
+using Helsenorge.Messaging.ServiceBus;
+using Microsoft.Extensions.Logging;
+
+namespace RepublishExample;
+
+internal static class Program
+{
+    private static string HostName = "tb.test.nhn.no";
+    private static int Port = 5671;
+    private static string Exchange = "NHNTESTServiceBus";
+    private static string UserName = "<username>";
+    private static string Password = "<password>";
+
+    private static int SourceHerId = 1234;
+
+    private static void Main()
+    {
+        var loggerFactory = new LoggerFactory();
+        var connectionString = new ConnectionString
+        {
+            HostName = HostName,
+            Port = Port,
+            UserName = UserName,
+            Password = Password,
+            Exchange = Exchange,
+        };
+
+        var client = new QueueClient(connectionString, loggerFactory.CreateLogger<QueueType>());
+
+        client.RepublishMessageFromDeadLetterToOriginQueue(SourceHerId);
+    }
+}

--- a/Examples/RepublishExample/Program.cs
+++ b/Examples/RepublishExample/Program.cs
@@ -7,7 +7,6 @@
  */
 
 using Helsenorge.Messaging.AdminLib;
-using Helsenorge.Messaging.AdminLib.RabbitMQ;
 using Helsenorge.Messaging.ServiceBus;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;

--- a/Examples/RepublishExample/RepublishExample.csproj
+++ b/Examples/RepublishExample/RepublishExample.csproj
@@ -11,4 +11,9 @@
       <ProjectReference Include="..\..\src\Helsenorge.Messaging.AdminLib\Helsenorge.Messaging.AdminLib.csproj" />
     </ItemGroup>
 
+    <ItemGroup>
+      <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
+      <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="6.0.0" />
+    </ItemGroup>
+
 </Project>

--- a/Examples/RepublishExample/RepublishExample.csproj
+++ b/Examples/RepublishExample/RepublishExample.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFramework>net6.0</TargetFramework>
+        <ImplicitUsings>disable</ImplicitUsings>
+        <Nullable>disable</Nullable>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\..\src\Helsenorge.Messaging.AdminLib\Helsenorge.Messaging.AdminLib.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/Messaging.sln
+++ b/Messaging.sln
@@ -70,6 +70,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ReceiveDecryptAndValidate",
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SubscriptionExample", "Examples\SubscriptionExample\SubscriptionExample.csproj", "{D49E63C8-DF43-45A9-804B-9B71E1DF5314}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Helsenorge.Messaging.AdminLib", "src\Helsenorge.Messaging.AdminLib\Helsenorge.Messaging.AdminLib.csproj", "{7FC8311D-C4CE-4947-AC16-5E5C40FE9919}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -132,6 +134,10 @@ Global
 		{D49E63C8-DF43-45A9-804B-9B71E1DF5314}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D49E63C8-DF43-45A9-804B-9B71E1DF5314}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D49E63C8-DF43-45A9-804B-9B71E1DF5314}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7FC8311D-C4CE-4947-AC16-5E5C40FE9919}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7FC8311D-C4CE-4947-AC16-5E5C40FE9919}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7FC8311D-C4CE-4947-AC16-5E5C40FE9919}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7FC8311D-C4CE-4947-AC16-5E5C40FE9919}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Messaging.sln
+++ b/Messaging.sln
@@ -74,6 +74,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Helsenorge.Messaging.AdminL
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Helsenorge.Messaging.AdminLib.Tests", "test\Helsenorge.Messaging.AdminLib.Tests\Helsenorge.Messaging.AdminLib.Tests.csproj", "{C6DD033F-80EF-4961-A07A-F35496C39821}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RepublishExample", "Examples\RepublishExample\RepublishExample.csproj", "{A59DE6F3-4F4B-4CB5-95CD-AFA81A5A31CF}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -144,6 +146,10 @@ Global
 		{C6DD033F-80EF-4961-A07A-F35496C39821}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C6DD033F-80EF-4961-A07A-F35496C39821}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C6DD033F-80EF-4961-A07A-F35496C39821}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A59DE6F3-4F4B-4CB5-95CD-AFA81A5A31CF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A59DE6F3-4F4B-4CB5-95CD-AFA81A5A31CF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A59DE6F3-4F4B-4CB5-95CD-AFA81A5A31CF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A59DE6F3-4F4B-4CB5-95CD-AFA81A5A31CF}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -162,6 +168,7 @@ Global
 		{F44A0630-B04A-4DDA-9536-E7AA3C80708A} = {0539614B-FB26-4204-B08C-D044A8DEAA41}
 		{DFF66B90-787E-4FAD-B830-9236ADC21983} = {0539614B-FB26-4204-B08C-D044A8DEAA41}
 		{D49E63C8-DF43-45A9-804B-9B71E1DF5314} = {0539614B-FB26-4204-B08C-D044A8DEAA41}
+		{A59DE6F3-4F4B-4CB5-95CD-AFA81A5A31CF} = {0539614B-FB26-4204-B08C-D044A8DEAA41}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {925B24E8-92AC-4D8D-959E-64DE4928A23B}

--- a/Messaging.sln
+++ b/Messaging.sln
@@ -72,6 +72,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SubscriptionExample", "Exam
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Helsenorge.Messaging.AdminLib", "src\Helsenorge.Messaging.AdminLib\Helsenorge.Messaging.AdminLib.csproj", "{7FC8311D-C4CE-4947-AC16-5E5C40FE9919}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Helsenorge.Messaging.AdminLib.Tests", "test\Helsenorge.Messaging.AdminLib.Tests\Helsenorge.Messaging.AdminLib.Tests.csproj", "{C6DD033F-80EF-4961-A07A-F35496C39821}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -138,6 +140,10 @@ Global
 		{7FC8311D-C4CE-4947-AC16-5E5C40FE9919}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{7FC8311D-C4CE-4947-AC16-5E5C40FE9919}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{7FC8311D-C4CE-4947-AC16-5E5C40FE9919}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C6DD033F-80EF-4961-A07A-F35496C39821}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C6DD033F-80EF-4961-A07A-F35496C39821}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C6DD033F-80EF-4961-A07A-F35496C39821}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C6DD033F-80EF-4961-A07A-F35496C39821}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Helsenorge.Messaging.AdminLib/ConnectionString.cs
+++ b/src/Helsenorge.Messaging.AdminLib/ConnectionString.cs
@@ -19,4 +19,5 @@ public class ConnectionString
     public string Password { get; set; }
     public string Exchange { get; set; }
     public string ClientProvidedName { get; set; }
+    public bool UseTls { get; set; } = true;
 }

--- a/src/Helsenorge.Messaging.AdminLib/ConnectionString.cs
+++ b/src/Helsenorge.Messaging.AdminLib/ConnectionString.cs
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2022, Norsk Helsenett SF and contributors
+ * See the file CONTRIBUTORS for details.
+ *
+ * This file is licensed under the MIT license
+ * available at https://raw.githubusercontent.com/helsenorge/Helsenorge.Messaging/master/LICENSE
+ */
+
+using System.Collections.Generic;
+
+namespace Helsenorge.Messaging.AdminLib;
+
+public class ConnectionString
+{
+    public string HostName { get; set; }
+    public int Port { get; set; }
+    public string VirtualHost { get; set; } = "/";
+    public string UserName { get; set; }
+    public string Password { get; set; }
+    public string Exchange { get; set; }
+    public string ClientProvidedName { get; set; }
+}

--- a/src/Helsenorge.Messaging.AdminLib/HeaderNotOfExpectedTypeException.cs
+++ b/src/Helsenorge.Messaging.AdminLib/HeaderNotOfExpectedTypeException.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace Helsenorge.Messaging.AdminLib;
+
+public class HeaderNotOfExpectedTypeException : Exception
+{
+    public HeaderNotOfExpectedTypeException(string name, Type type)
+        : base($"Expected header: '{name}' to of type '{type.FullName}'")
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/src/Helsenorge.Messaging.AdminLib/Helsenorge.Messaging.AdminLib.csproj
+++ b/src/Helsenorge.Messaging.AdminLib/Helsenorge.Messaging.AdminLib.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net6.0</TargetFramework>
+        <ImplicitUsings>disable</ImplicitUsings>
+        <Nullable>disable</Nullable>
+    </PropertyGroup>
+
+</Project>

--- a/src/Helsenorge.Messaging.AdminLib/Helsenorge.Messaging.AdminLib.csproj
+++ b/src/Helsenorge.Messaging.AdminLib/Helsenorge.Messaging.AdminLib.csproj
@@ -11,4 +11,8 @@
         <PackageReference Include="RabbitMQ.Client" Version="6.4.0" />
     </ItemGroup>
 
+    <ItemGroup>
+      <ProjectReference Include="..\Helsenorge.Messaging\Helsenorge.Messaging.csproj" />
+    </ItemGroup>
+
 </Project>

--- a/src/Helsenorge.Messaging.AdminLib/Helsenorge.Messaging.AdminLib.csproj
+++ b/src/Helsenorge.Messaging.AdminLib/Helsenorge.Messaging.AdminLib.csproj
@@ -15,4 +15,13 @@
       <ProjectReference Include="..\Helsenorge.Messaging\Helsenorge.Messaging.csproj" />
     </ItemGroup>
 
+    <ItemGroup>
+        <AssemblyAttribute Include="System.Reflection.AssemblyKeyFile">
+            <_Parameter1>../../tools/key.snk</_Parameter1>
+        </AssemblyAttribute>
+        <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+            <_Parameter1>Helsenorge.Messaging.AdminLib.Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100773d7b513076df908a05edadb53a26effc169310d844ff47ed842bebef258bcfda39e2c62e4d6ceabb04037a24bcd285efd882ee7623170664411d5f5107cd2756221ba572b4903bd45153c192cae7c544ea23b88f814c49a4709218355eac9398524c353f4a5678ea9a2755bb012707d2de25019af5fd511b1f48aa5a6eadd4</_Parameter1>
+        </AssemblyAttribute>
+    </ItemGroup>
+
 </Project>

--- a/src/Helsenorge.Messaging.AdminLib/Helsenorge.Messaging.AdminLib.csproj
+++ b/src/Helsenorge.Messaging.AdminLib/Helsenorge.Messaging.AdminLib.csproj
@@ -6,4 +6,9 @@
         <Nullable>disable</Nullable>
     </PropertyGroup>
 
+    <ItemGroup>
+        <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
+        <PackageReference Include="RabbitMQ.Client" Version="6.4.0" />
+    </ItemGroup>
+
 </Project>

--- a/src/Helsenorge.Messaging.AdminLib/MissingHeaderException.cs
+++ b/src/Helsenorge.Messaging.AdminLib/MissingHeaderException.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace Helsenorge.Messaging.AdminLib;
+
+public class MissingHeaderException : Exception
+{
+    public MissingHeaderException(string name)
+        : base($"Header with name: '{name}' is missing from the Headers dictionary.")
+    {
+
+    }
+}

--- a/src/Helsenorge.Messaging.AdminLib/QueueClient.cs
+++ b/src/Helsenorge.Messaging.AdminLib/QueueClient.cs
@@ -78,7 +78,7 @@ public class QueueClient : IDisposable, IAsyncDisposable
         if (string.IsNullOrWhiteSpace(destinationQueue))
             throw new ArgumentException("Argument must contain the queue name.", nameof(destinationQueue));
 
-        _logger.LogInformation($"Start-PublishMessageAndAckIfSuccessful - Moving message with delivery tag '{message.DeliveryTag}' to '{destinationQueue}'. MessageId:{message.BasicProperties.MessageId}");
+        _logger.LogInformation($"Start-PublishMessageAndAckIfSuccessful - Starting publish process of message with MessageId: {message.BasicProperties.MessageId} to DestinationQueue: '{destinationQueue}'.");
 
         var confirmed = true;
         if (waitForConfirm)
@@ -102,17 +102,17 @@ public class QueueClient : IDisposable, IAsyncDisposable
             // The message was confirmed published to the exchange so positively acknowledge that the message has been processed.
             Channel.BasicAck(message.DeliveryTag, multiple: false);
 
-            _logger.LogInformation($"PublishMessageAndAckIfSuccessful - Message with delivery tag '{message.DeliveryTag}' was ACKed because it was successfully moved to '{destinationQueue}' MessageId:{message.BasicProperties.MessageId}.");
+            _logger.LogInformation($"PublishMessageAndAckIfSuccessful - Message with MessageId: '{message.BasicProperties.MessageId}' was ACKed because publish to DestinationQueue: '{destinationQueue}' was successful.");
         }
         else
         {
             // The message was not confirmed published to the exchange so negatively acknowledge that the message should be re-queued.
             Channel.BasicNack(message.DeliveryTag, multiple: false, requeue: true);
 
-            _logger.LogInformation($"PublishMessageAndAckIfSuccessful - Message with delivery tag '{message.DeliveryTag}' was NACKed because it was unsuccessfully moved to '{destinationQueue}' MessageId:{message.BasicProperties.MessageId}.");
+            _logger.LogInformation($"PublishMessageAndAckIfSuccessful - Message with MessageId: '{message.BasicProperties.MessageId}' was NACKed because publish to DestinationQueue: '{destinationQueue}' was unsuccessful.");
         }
 
-        _logger.LogInformation($"End-PublishMessageAndAckIfSuccessful - Message with delivery tag '{message.DeliveryTag}' was moved to '{destinationQueue}'. MessageId:{message.BasicProperties.MessageId}");
+        _logger.LogInformation($"End-PublishMessageAndAckIfSuccessful - Message with MessageId: '{message.BasicProperties.MessageId}' and DeliveryTag '{message.DeliveryTag}' was published to DestinationQueue: '{destinationQueue}'.");
     }
 
     /// <summary>

--- a/src/Helsenorge.Messaging.AdminLib/QueueClient.cs
+++ b/src/Helsenorge.Messaging.AdminLib/QueueClient.cs
@@ -12,7 +12,7 @@ using Microsoft.Extensions.Logging;
 using Helsenorge.Messaging.ServiceBus;
 using RabbitMQ.Client;
 
-namespace Helsenorge.Messaging.AdminLib.RabbitMQ;
+namespace Helsenorge.Messaging.AdminLib;
 
 public class QueueClient : IDisposable, IAsyncDisposable
 {

--- a/src/Helsenorge.Messaging.AdminLib/QueueClient.cs
+++ b/src/Helsenorge.Messaging.AdminLib/QueueClient.cs
@@ -69,6 +69,14 @@ public class QueueClient : IDisposable, IAsyncDisposable
         return ValueTask.CompletedTask;
     }
 
+    /// <summary>
+    /// Publishes a message in form of a BasicGetResult using the specified exchange and destination queue.
+    /// </summary>
+    /// <param name="message">The message in form of a BasicGetResult.</param>
+    /// <param name="exchange">The exchange to publish the message to.</param>
+    /// <param name="destinationQueue">The destination queue we want to message to be routed to.</param>
+    /// <param name="mandatory">If this flag is true we fail if no ACK is received after message is published.</param>
+    /// <param name="waitForConfirm">If this flag is true we wait for ACK to be confirmed before we ACK or NACK the delivery tag of the BasicGetResult.</param>
     private void PublishMessageAndAckIfSuccessful(BasicGetResult message, string exchange, string destinationQueue, bool mandatory = true, bool waitForConfirm = true)
     {
         if (message == null)

--- a/src/Helsenorge.Messaging.AdminLib/QueueUtilities.cs
+++ b/src/Helsenorge.Messaging.AdminLib/QueueUtilities.cs
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2022, Norsk Helsenett SF and contributors
+ * See the file CONTRIBUTORS for details.
+ *
+ * This file is licensed under the MIT license
+ * available at https://raw.githubusercontent.com/helsenorge/Helsenorge.Messaging/master/LICENSE
+ */
+
+using System;
+using Helsenorge.Messaging.ServiceBus;
+
+namespace Helsenorge.Messaging.AdminLib;
+
+internal static class QueueUtilities
+{
+    internal static string ConstructQueueName(int herId, QueueType queueType)
+    {
+        return queueType switch
+        {
+            QueueType.Asynchronous => $"{herId}_async",
+            QueueType.Synchronous => $"{herId}_sync",
+            QueueType.Error => $"{herId}_error",
+            QueueType.DeadLetter => $"{herId}_dl",
+            QueueType.SynchronousReply => $"{herId}_syncreply",
+            _ => throw new ArgumentOutOfRangeException(nameof(queueType), queueType, $"The queue type: '{queueType}' is not supported."),
+        };
+    }
+}

--- a/src/Helsenorge.Messaging.AdminLib/QueueUtilities.cs
+++ b/src/Helsenorge.Messaging.AdminLib/QueueUtilities.cs
@@ -7,6 +7,8 @@
  */
 
 using System;
+using System.Collections.Generic;
+using System.Text;
 using Helsenorge.Messaging.ServiceBus;
 
 namespace Helsenorge.Messaging.AdminLib;
@@ -24,5 +26,17 @@ internal static class QueueUtilities
             QueueType.SynchronousReply => $"{herId}_syncreply",
             _ => throw new ArgumentOutOfRangeException(nameof(queueType), queueType, $"The queue type: '{queueType}' is not supported."),
         };
+    }
+
+    internal static string GetByteHeaderAsString(IDictionary<string, object> headers, string name)
+    {
+        if (!headers.ContainsKey(name))
+            throw new MissingHeaderException(name);
+
+        var bytes = headers[name] as byte[];
+        if (bytes == null)
+            throw new HeaderNotOfExpectedTypeException(name, typeof(byte[]));
+
+        return Encoding.UTF8.GetString(bytes);
     }
 }

--- a/src/Helsenorge.Messaging.AdminLib/RabbitMQ/QueueClient.cs
+++ b/src/Helsenorge.Messaging.AdminLib/RabbitMQ/QueueClient.cs
@@ -9,6 +9,7 @@
 using System;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
+using Helsenorge.Messaging.ServiceBus;
 using RabbitMQ.Client;
 
 namespace Helsenorge.Messaging.AdminLib.RabbitMQ;
@@ -61,5 +62,27 @@ public class QueueClient : IDisposable, IAsyncDisposable
     {
         Dispose();
         return ValueTask.CompletedTask;
+    }
+
+    /// <summary>
+    /// A method to retrieve the number of messages currently on the queue by specifiying the HER-id and the queue type.
+    /// </summary>
+    /// <param name="herId">The HER-id of the queue.</param>
+    /// <param name="queueType">The type of queue.</param>
+    /// <returns>The number of messages currently on the queue.</returns>
+    public uint GetMessageCount(int herId, QueueType queueType)
+    {
+        var queue = QueueUtilities.ConstructQueueName(herId, queueType);
+        return GetMessageCount(queue);
+    }
+
+    /// <summary>
+    /// A method to retrieve the number of messages currently on the queue by explicitly naming the queue.
+    /// </summary>
+    /// <param name="queue">The name of the queue.</param>
+    /// <returns>The number of messages currently on the queue.</returns>
+    public uint GetMessageCount(string queue)
+    {
+        return Channel.MessageCount(queue);
     }
 }

--- a/src/Helsenorge.Messaging.AdminLib/RabbitMQ/QueueClient.cs
+++ b/src/Helsenorge.Messaging.AdminLib/RabbitMQ/QueueClient.cs
@@ -78,7 +78,7 @@ public class QueueClient : IDisposable, IAsyncDisposable
         if (string.IsNullOrWhiteSpace(destinationQueue))
             throw new ArgumentException("Argument must contain the queue name.", nameof(destinationQueue));
 
-        _logger.LogInformation($"Start-PublishMessageAndAckIfSuccessful - Moving message with delivery tag '{message.DeliveryTag}' to '{destinationQueue}'.");
+        _logger.LogInformation($"Start-PublishMessageAndAckIfSuccessful - Moving message with delivery tag '{message.DeliveryTag}' to '{destinationQueue}'. MessageId:{message.BasicProperties.MessageId}");
 
         // Publish message to destination queue.
         Channel.BasicPublish(exchange, destinationQueue, mandatory, message.BasicProperties, message.Body);
@@ -87,17 +87,17 @@ public class QueueClient : IDisposable, IAsyncDisposable
             // The message was confirmed published to the exchange so positively acknowledge that the message has been processed.
             Channel.BasicAck(message.DeliveryTag, multiple: false);
 
-            _logger.LogInformation($"PublishMessageAndAckIfSuccessful - Message with delivery tag '{message.DeliveryTag}' was ACKed because it was successfully moved to '{destinationQueue}'.");
+            _logger.LogInformation($"PublishMessageAndAckIfSuccessful - Message with delivery tag '{message.DeliveryTag}' was ACKed because it was successfully moved to '{destinationQueue}' MessageId:{message.BasicProperties.MessageId}.");
         }
         else
         {
             // The message was not confirmed published to the exchange so negatively acknowledge that the message should be re-queued.
             Channel.BasicNack(message.DeliveryTag, multiple: false, requeue: true);
 
-            _logger.LogInformation($"PublishMessageAndAckIfSuccessful - Message with delivery tag '{message.DeliveryTag}' was NACKed because it was unsuccessfully moved to '{destinationQueue}'.");
+            _logger.LogInformation($"PublishMessageAndAckIfSuccessful - Message with delivery tag '{message.DeliveryTag}' was NACKed because it was unsuccessfully moved to '{destinationQueue}' MessageId:{message.BasicProperties.MessageId}.");
         }
 
-        _logger.LogInformation($"End-PublishMessageAndAckIfSuccessful - Message with delivery tag '{message.DeliveryTag}' was moved to '{destinationQueue}'.");
+        _logger.LogInformation($"End-PublishMessageAndAckIfSuccessful - Message with delivery tag '{message.DeliveryTag}' was moved to '{destinationQueue}'. MessageId:{message.BasicProperties.MessageId}");
     }
 
     /// <summary>

--- a/src/Helsenorge.Messaging.AdminLib/RabbitMQ/QueueClient.cs
+++ b/src/Helsenorge.Messaging.AdminLib/RabbitMQ/QueueClient.cs
@@ -144,7 +144,7 @@ public class QueueClient : IDisposable, IAsyncDisposable
         Channel.BasicReturn += (_, args) =>
         {
             if (args.ReplyCode == NoRoute)
-                _logger.LogError($"MoveMessages-BasicReturn - Message is un-routable: MessageId: '{args.BasicProperties.MessageId}', CorrelationId: '{args.BasicProperties.CorrelationId}', Exchange: '{args.Exchange}', RoutingKey: '{args.RoutingKey}', ReplyCode: '{args.ReplyCode}', ReplyText: '{args.ReplyText}'");
+                _logger.LogError($"MoveMessages-BasicReturn - The Queue '{sourceQueue} does not exist or is not bound correctly. Message is un-routable: MessageId: '{args.BasicProperties.MessageId}', CorrelationId: '{args.BasicProperties.CorrelationId}', Exchange: '{args.Exchange}', RoutingKey: '{args.RoutingKey}', ReplyCode: '{args.ReplyCode}', ReplyText: '{args.ReplyText}'");
             else
                 _logger.LogInformation($"MoveMessages-BasicReturn - MessageId: '{args.BasicProperties.MessageId}', CorrelationId: '{args.BasicProperties.CorrelationId}', Exchange: '{args.Exchange}', RoutingKey: '{args.RoutingKey}', ReplyCode: '{args.ReplyCode}', ReplyText: '{args.ReplyText}'");
         };

--- a/src/Helsenorge.Messaging.AdminLib/RabbitMQ/QueueClient.cs
+++ b/src/Helsenorge.Messaging.AdminLib/RabbitMQ/QueueClient.cs
@@ -1,0 +1,65 @@
+﻿/*
+ * Copyright (c) 2022, Norsk Helsenett SF and contributors
+ * See the file CONTRIBUTORS for details.
+ *
+ * This file is licensed under the MIT license
+ * available at https://raw.githubusercontent.com/helsenorge/Helsenorge.Messaging/master/LICENSE
+ */
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using RabbitMQ.Client;
+
+namespace Helsenorge.Messaging.AdminLib.RabbitMQ;
+
+public class QueueClient : IDisposable, IAsyncDisposable
+{
+    private readonly ConnectionString _connectionString;
+    private readonly ILogger _logger;
+    private IConnectionFactory _connectionFactory;
+    private IConnection _connection;
+    private IModel _channel;
+
+    public QueueClient(ConnectionString connectionString, ILogger logger)
+    {
+        _connectionString = connectionString;
+        _logger = logger;
+    }
+
+    private IConnectionFactory ConnectionFactory
+    {
+        get
+        {
+            return _connectionFactory ??= new ConnectionFactory
+            {
+                Uri = new Uri($"amqps://{_connectionString.HostName}"),
+                UserName = _connectionString.UserName,
+                Password = _connectionString.Password,
+                VirtualHost = string.IsNullOrWhiteSpace(_connectionString.VirtualHost) ? "/" : _connectionString.VirtualHost,
+                ClientProvidedName = _connectionString.ClientProvidedName,
+            };
+        }
+    }
+
+    private IConnection Connection
+    {
+        get { return _connection ??= ConnectionFactory.CreateConnection(); }
+    }
+
+    private IModel Channel
+    {
+        get { return _channel ??= Connection.CreateModel(); }
+    }
+
+    public void Dispose()
+    {
+        _connection?.Dispose();
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        Dispose();
+        return ValueTask.CompletedTask;
+    }
+}

--- a/src/Helsenorge.Messaging.AdminLib/RabbitMQ/QueueClient.cs
+++ b/src/Helsenorge.Messaging.AdminLib/RabbitMQ/QueueClient.cs
@@ -39,7 +39,7 @@ public class QueueClient : IDisposable, IAsyncDisposable
         {
             return _connectionFactory ??= new ConnectionFactory
             {
-                Uri = new Uri($"amqps://{_connectionString.HostName}"),
+                Uri = new Uri($"{(_connectionString.UseTls ? "amqps": "amqp")}://{_connectionString.HostName}"),
                 UserName = _connectionString.UserName,
                 Password = _connectionString.Password,
                 VirtualHost = string.IsNullOrWhiteSpace(_connectionString.VirtualHost) ? "/" : _connectionString.VirtualHost,

--- a/src/Helsenorge.Messaging.AdminLib/SourceAndDestinationIdenticalException.cs
+++ b/src/Helsenorge.Messaging.AdminLib/SourceAndDestinationIdenticalException.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace Helsenorge.Messaging.AdminLib;
+
+public class SourceAndDestinationIdenticalException : Exception
+{
+    public SourceAndDestinationIdenticalException(string source, string destination)
+        : base($"The source queue and destination queue cannot be identical. Source: '{source}'. Destination: '{destination}'")
+    {
+    }
+}

--- a/src/Helsenorge.Messaging/ServiceBus/QueueType.cs
+++ b/src/Helsenorge.Messaging/ServiceBus/QueueType.cs
@@ -1,5 +1,5 @@
 ﻿/* 
- * Copyright (c) 2020, Norsk Helsenett SF and contributors
+ * Copyright (c) 2020-2022, Norsk Helsenett SF and contributors
  * See the file CONTRIBUTORS for details.
  * 
  * This file is licensed under the MIT license
@@ -28,6 +28,10 @@ namespace Helsenorge.Messaging.ServiceBus
         /// <summary>
         /// Queue used for synchronous reply messages
         /// </summary>
-        SynchronousReply
+        SynchronousReply,
+        /// <summary>
+        /// Queue where deadlettered messages are stored
+        /// </summary>
+        DeadLetter,
     }
 }

--- a/test/Helsenorge.Messaging.AdminLib.Tests/Helsenorge.Messaging.AdminLib.Tests.csproj
+++ b/test/Helsenorge.Messaging.AdminLib.Tests/Helsenorge.Messaging.AdminLib.Tests.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net6.0</TargetFramework>
+        <ImplicitUsings>disable</ImplicitUsings>
+        <Nullable>disable</Nullable>
+    </PropertyGroup>
+
+</Project>

--- a/test/Helsenorge.Messaging.AdminLib.Tests/Helsenorge.Messaging.AdminLib.Tests.csproj
+++ b/test/Helsenorge.Messaging.AdminLib.Tests/Helsenorge.Messaging.AdminLib.Tests.csproj
@@ -6,4 +6,23 @@
         <Nullable>disable</Nullable>
     </PropertyGroup>
 
+    <ItemGroup>
+      <ProjectReference Include="..\..\src\Helsenorge.Messaging.AdminLib\Helsenorge.Messaging.AdminLib.csproj" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
+      <PackageReference Include="xunit" Version="2.4.2" />
+      <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+        <PrivateAssets>all</PrivateAssets>
+        <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      </PackageReference>
+    </ItemGroup>
+
+    <ItemGroup>
+      <AssemblyAttribute Include="System.Reflection.AssemblyKeyFile">
+        <_Parameter1>../../tools/key.snk</_Parameter1>
+      </AssemblyAttribute>
+    </ItemGroup>
+
 </Project>

--- a/test/Helsenorge.Messaging.AdminLib.Tests/QueueClientTests.cs
+++ b/test/Helsenorge.Messaging.AdminLib.Tests/QueueClientTests.cs
@@ -1,0 +1,28 @@
+﻿/*
+ * Copyright (c) 2022, Norsk Helsenett SF and contributors
+ * See the file CONTRIBUTORS for details.
+ *
+ * This file is licensed under the MIT license
+ * available at https://raw.githubusercontent.com/helsenorge/Helsenorge.Messaging/master/LICENSE
+*/
+
+using Helsenorge.Messaging.ServiceBus;
+using Xunit;
+
+namespace Helsenorge.Messaging.AdminLib.Tests;
+
+public class QueueClientTests
+{
+    [Theory]
+    [InlineData(1234, QueueType.Asynchronous, "1234_async")]
+    [InlineData(4567, QueueType.Synchronous, "4567_sync")]
+    [InlineData(8901, QueueType.SynchronousReply, "8901_syncreply")]
+    [InlineData(2345, QueueType.Error, "2345_error")]
+    [InlineData(6789, QueueType.DeadLetter, "6789_dl")]
+    public void Assert_QueueName_Is_Correctly_Constructed(int herId, QueueType queueType, string expectedQueueName)
+    {
+        var actualQueueName = QueueUtilities.ConstructQueueName(herId, queueType);
+
+        Assert.Equal(expectedQueueName, actualQueueName);
+    }
+}


### PR DESCRIPTION
This adds Helsenorge.Messaging.AdminLib consisting of a QueueClient with the methods:
- GetMessageCount()
- RepublishMessagesFromDeadLetter()
- MoveMessages()

Currently the library is simplified. It will be expanded based on needs from the ServiceBus migration project.