### PR TITLE
ServiceBus: Do not copy reference types from original message in Clone()

### DIFF
--- a/src/Helsenorge.Messaging/ServiceBus/ServiceBusMessage.cs
+++ b/src/Helsenorge.Messaging/ServiceBus/ServiceBusMessage.cs
@@ -240,15 +240,67 @@ namespace Helsenorge.Messaging.ServiceBus
         [DebuggerStepThrough]
         public IMessagingMessage Clone(bool includePayload = true)
         {
-            var clone = new Message
+            var clone = new Message();
+
+            if (_implementation.Header != null)
             {
-                Header = _implementation.Header,
-                DeliveryAnnotations = _implementation.DeliveryAnnotations,
-                MessageAnnotations = _implementation.MessageAnnotations,
-                Properties = _implementation.Properties,
-                ApplicationProperties = _implementation.ApplicationProperties,
-                Footer = _implementation.Footer
-            };
+                clone.Header = new Header
+                {
+                    DeliveryCount = _implementation.Header.DeliveryCount,
+                    Durable = _implementation.Header.Durable,
+                    FirstAcquirer = _implementation.Header.FirstAcquirer,
+                    Priority = _implementation.Header.Priority,
+                    Ttl = _implementation.Header.Ttl,
+                };
+            }
+
+            if (_implementation.DeliveryAnnotations != null)
+            {
+                clone.DeliveryAnnotations = new DeliveryAnnotations();
+                foreach (var key in _implementation.DeliveryAnnotations.Map.Keys)
+                    clone.DeliveryAnnotations.Map.Add(key, _implementation.DeliveryAnnotations.Map[key]);
+            }
+
+            if (_implementation.MessageAnnotations != null)
+            {
+                clone.MessageAnnotations = new MessageAnnotations();
+                foreach (var key in _implementation.MessageAnnotations.Map.Keys)
+                    clone.MessageAnnotations.Map.Add(key, _implementation.MessageAnnotations.Map[key]);
+            }
+
+            if (_implementation.Properties != null)
+            {
+                clone.Properties = new Properties
+                {
+                    Subject = _implementation.Properties.Subject,
+                    To = _implementation.Properties.To,
+                    ContentEncoding = _implementation.Properties.ContentEncoding,
+                    ContentType = _implementation.Properties.ContentType,
+                    CorrelationId = _implementation.Properties.CorrelationId,
+                    CreationTime = _implementation.Properties.CreationTime,
+                    GroupId = _implementation.Properties.GroupId,
+                    GroupSequence = _implementation.Properties.GroupSequence,
+                    MessageId = _implementation.Properties.MessageId,
+                    ReplyTo = _implementation.Properties.ReplyTo,
+                    UserId = _implementation.Properties.UserId,
+                    AbsoluteExpiryTime = _implementation.Properties.AbsoluteExpiryTime,
+                    ReplyToGroupId = _implementation.Properties.ReplyToGroupId,
+                };
+            }
+
+            if (_implementation.ApplicationProperties != null)
+            {
+                clone.ApplicationProperties = new ApplicationProperties();
+                foreach (var key in _implementation.ApplicationProperties.Map.Keys)
+                    clone.ApplicationProperties.Map.Add(key, _implementation.ApplicationProperties.Map[key]);
+            }
+
+            if (_implementation.Footer != null)
+            {
+                clone.Footer = new Footer();
+                foreach (var key in _implementation.Footer.Map.Keys)
+                    clone.Footer.Map.Add(key, _implementation.Footer.Map[key]);
+            }
 
             if (includePayload && _implementation.Body is byte[])
             {

--- a/test/Helsenorge.Messaging.Tests/ServiceBus/ServiceBusMessageTests.cs
+++ b/test/Helsenorge.Messaging.Tests/ServiceBus/ServiceBusMessageTests.cs
@@ -285,5 +285,28 @@ namespace Helsenorge.Messaging.Tests.ServiceBus
                 Assert.IsNull(((Message)clonedMessage.OriginalObject).Body);
             }
         }
+
+        [TestMethod]
+        public void Modifications_On_Cloned_Message_Should_Not_Affect_Original_Message()
+        {
+            var toHerId = 123;
+            var fromHerId = 456;
+
+            using var originalMessage = new ServiceBusMessage(new Message());
+            originalMessage.ToHerId = toHerId;
+            originalMessage.FromHerId = fromHerId;
+
+            var clonedMessage = originalMessage.Clone(includePayload: false);
+
+            clonedMessage.FromHerId = originalMessage.ToHerId;
+            clonedMessage.ToHerId = originalMessage.FromHerId;
+
+            // Assert that clonedMessage has its ToHerId and FromHerId switched.
+            Assert.AreEqual(toHerId, clonedMessage.FromHerId);
+            Assert.AreEqual(fromHerId, clonedMessage.ToHerId);
+            // Assert that originalMessage has ToHerId and FromHerId set as it was originally.
+            Assert.AreEqual(toHerId, originalMessage.ToHerId);
+            Assert.AreEqual(fromHerId, originalMessage.FromHerId);
+        }
     }
 }


### PR DESCRIPTION
Copying reference types from the original message causes hard to find bugs when we start to manipulate the values of these references.

For example: in SendError() before we send a reply to the recipients error queue we:
1. clone the message
2. Switch ServiceBusMessage.FromHerId and ServiceBusMessage.ToHerId on the cloned message
3. The result we end up with is ToHerId and FromHerId both have the same HER-id
4. In addition we have manipulated the values of both originalMessage and clonedMessage since in the underlying object these are stored in a Dictionary/Map which is a reference type.

In-house reference: [283463](https://dev.azure.com/nhnfelles/Helsenorge/_workitems/edit/283463)

Supersedes #414