### PR TITLE
Messaging: Temporarily use Receive instead of ReceiveAsync

### DIFF
--- a/src/Helsenorge.Messaging/ServiceBus/Receivers/MessageListener.cs
+++ b/src/Helsenorge.Messaging/ServiceBus/Receivers/MessageListener.cs
@@ -152,7 +152,7 @@ namespace Helsenorge.Messaging.ServiceBus.Receivers
             IMessagingMessage message;
             try
             {
-                message = await _messageReceiver.ReceiveAsync(ReadTimeout).ConfigureAwait(false);
+                message = _messageReceiver.Receive(ReadTimeout);
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
Until we have proper API support to separate sync and async APIs, so the users of the library can make a conscious decision on whether they can use the sync or async APIs, let's use the sync Receive method.

There is a potential foot gun when using the ReceiveAsync() API in which you block the message pump in the AmqpNetLite if you do a "long-running" blocking I/O / sync operation.

More information here: https://github.com/Azure/amqpnetlite/issues/556