### PR TITLE
not throwing taskcanceledexception when token i cancelled

### DIFF
--- a/src/Helsenorge.Messaging/ServiceBus/Receivers/MessageListener.cs
+++ b/src/Helsenorge.Messaging/ServiceBus/Receivers/MessageListener.cs
@@ -130,7 +130,9 @@ namespace Helsenorge.Messaging.ServiceBus.Receivers
                     Logger.LogException($"Generic service bus error at '{Core.HostnameAndPath}/{QueueName}'", ex);
                     // if there are problems with the message bus, we don't get interval of the ReadTimeout
                     // pause a bit so that we don't take over the whole system
-                    await Task.Delay(5000, cancellation).ConfigureAwait(false);
+                    await Task.Delay(5000, cancellation)
+                        .ContinueWith(task => task.Exception == default)
+                        .ConfigureAwait(false);
                 }
                 finally
                 {


### PR DESCRIPTION
When disposing or stopping MessageServer cancellationtoken was cancelled, this give exception in the Task.Delay and the Shutdown of the Sender- Receiver- and FactoryPool never got called.

People calling Stop or Dispose when the windows-service was stopped/restarted do not notice this bug since all connections are closed when the MessageServer is destroyed.

For those who call dispose on MessageServer and then construct a new MessageServer and Start the new one, will get connectionsleak "hanging in there" for ever.

Thanks to @sandisa doing great research for this bug
