### PR TITLE
Messaging: Expose GroupId on IMessagingMessage 

### DIFF
--- a/src/Helsenorge.Messaging/Abstractions/IMessagingMessage.cs
+++ b/src/Helsenorge.Messaging/Abstractions/IMessagingMessage.cs
@@ -67,6 +67,10 @@ namespace Helsenorge.Messaging.Abstractions
         /// </summary>
         string MessageId { get; set; }
         /// <summary>
+        /// Gets or sets the GroupId
+        /// </summary>
+        string GroupId { get; set; }
+        /// <summary>
         /// Gets or sets the path where replies are sent
         /// </summary>
         string ReplyTo { get; set; }

--- a/src/Helsenorge.Messaging/ServiceBus/ServiceBusMessage.cs
+++ b/src/Helsenorge.Messaging/ServiceBus/ServiceBusMessage.cs
@@ -181,6 +181,15 @@ namespace Helsenorge.Messaging.ServiceBus
             [DebuggerStepThrough]
             set => GetMessageProperties().MessageId = value;
         }
+        public string GroupId
+        {
+            [DebuggerStepThrough]
+            get => GetMessageProperties().GroupId;
+
+            [DebuggerStepThrough]
+            set => GetMessageProperties().GroupId = value;
+        }
+
         public string ReplyTo
         {
             [DebuggerStepThrough]

--- a/test/Helsenorge.Messaging.Tests/Mocks/MockMessage.cs
+++ b/test/Helsenorge.Messaging.Tests/Mocks/MockMessage.cs
@@ -49,6 +49,7 @@ namespace Helsenorge.Messaging.Tests.Mocks
         public string CorrelationId { get; set; }
         public string MessageFunction { get; set; }
         public string MessageId { get; set; }
+        public string GroupId { get; set; }
         public string ReplyTo { get; set; }
         public DateTime ScheduledEnqueueTimeUtc { get; set; }
         public TimeSpan TimeToLive { get; set; }


### PR DESCRIPTION
This exposes the GroupId AMQP property on IMessagingMessage.

This property is used by Iplos messages to split large file into
smaller files.