### PR TITLE
Registries: Add factory methods for CollaborationProtocol{Message,Profile,Role}

### DIFF
--- a/src/Helsenorge.Registries/Abstractions/CollaborationProtocolMessage.cs
+++ b/src/Helsenorge.Registries/Abstractions/CollaborationProtocolMessage.cs
@@ -1,5 +1,5 @@
 ﻿/* 
- * Copyright (c) 2020, Norsk Helsenett SF and contributors
+ * Copyright (c) 2020-2023, Norsk Helsenett SF and contributors
  * See the file CONTRIBUTORS for details.
  * 
  * This file is licensed under the MIT license
@@ -8,6 +8,9 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
+using System.Xml.Linq;
+using Helsenorge.Registries.Utilities;
 
 namespace Helsenorge.Registries.Abstractions
 {
@@ -32,6 +35,138 @@ namespace Helsenorge.Registries.Abstractions
     [Serializable]
     public class CollaborationProtocolMessage
     {
+        private static XNamespace NameSpace = "http://www.oasis-open.org/committees/ebxml-cppa/schema/cpp-cpa-2_0.xsd";
+
+        /// <summary>
+        /// Returns a <see cref="CollaborationProtocolMessage"/> from a ThisPartyActionBinding XML element.
+        /// </summary>
+        /// <param name="thisPartyActionBinding">The ThisPartyActionBinding XML element.</param>
+        /// <param name="partyInfo">The PartyInfo XML node.</param>
+        /// <param name="messageFunction">The message function this <see cref="CollaborationProtocolMessage"/> represents.</param>
+        /// <returns></returns>
+        /// <example>
+        /// <![CDATA[
+        ///		<tns:ThisPartyActionBinding tns:id="Dialog_Innbygger_Ekonsultasjon-v1p1-DIALOG_INNBYGGER_EKONSULTASJONreceiver-Receive-APPREC-v1p1" tns:action="APPREC" tns:packageId="package_apprec_v1p1" xlink:type="simple">
+        ///			<tns:BusinessTransactionCharacteristics tns:isNonRepudiationRequired="true" tns:isNonRepudiationReceiptRequired="true" tns:isConfidential="none" tns:isAuthenticated="none" tns:isTamperProof="none" tns:isAuthorizationRequired="false" tns:isIntelligibleCheckRequired="false" tns:timeToPerform="P180M" />
+        ///			<tns:ChannelId>AMQPAsync_81b6cff2-7f96-4bae-b314-d70f7b0e1d62</tns:ChannelId>
+        ///		</tns:ThisPartyActionBinding>
+        /// ]]>
+        /// </example>
+        public static CollaborationProtocolMessage CreateFromThisPartyActionBinding(XElement thisPartyActionBinding, XContainer partyInfo, string messageFunction)
+        {
+            if (thisPartyActionBinding == null) throw new ArgumentNullException(nameof(thisPartyActionBinding));
+            if (partyInfo == null) throw new ArgumentNullException(nameof(partyInfo));
+
+            //	<tns:ThisPartyActionBinding tns:id="Dialog_Innbygger_Ekonsultasjon-v1p1-DIALOG_INNBYGGER_EKONSULTASJONreceiver-Receive-APPREC-v1p1" tns:action="APPREC" tns:packageId="package_apprec_v1p1" xlink:type="simple">
+            //		<tns:BusinessTransactionCharacteristics tns:isNonRepudiationRequired="true" tns:isNonRepudiationReceiptRequired="true" tns:isConfidential="none" tns:isAuthenticated="none" tns:isTamperProof="none" tns:isAuthorizationRequired="false" tns:isIntelligibleCheckRequired="false" tns:timeToPerform="P180M" />
+            //		<tns:ChannelId>AMQPAsync_81b6cff2-7f96-4bae-b314-d70f7b0e1d62</tns:ChannelId>
+            //	</tns:ThisPartyActionBinding>
+            var channelIdNode = thisPartyActionBinding.Element(NameSpace + "ChannelId");
+            if (channelIdNode == null) throw new InvalidOperationException("ChannelId node is empty");
+
+            //<tns:DeliveryChannel tns:channelId="AMQPAsync_81b6cff2-7f96-4bae-b314-d70f7b0e1d62" tns:transportId="transport_0_1" tns:docExchangeId="docexchange_async_amqp">
+            //		<tns:MessagingCharacteristics />
+            // </tns:DeliveryChannel>
+
+            var transportId = (from c in partyInfo.Elements(NameSpace + "DeliveryChannel")
+                    where c.Attribute(NameSpace + "channelId").Value.Equals(channelIdNode.Value)
+                    select c.Attribute(NameSpace + "transportId").Value).FirstOrDefault();
+            if (transportId == null) throw new InvalidOperationException("TransportId is empty");
+
+            // <tns:Transport tns:transportId="transport_0_1">
+            //	<tns:TransportSender>
+            //		<tns:TransportProtocol tns:version="1.0">AMQP</tns:TransportProtocol>
+            //	</tns:TransportSender>
+            //	<tns:TransportReceiver>
+            //		<tns:TransportProtocol tns:version="1.0">AMQP</tns:TransportProtocol>
+            //		<tns:Endpoint tns:uri="sb.test.nhn.no/DigitalDialog/93238_async" />
+            //	</tns:TransportReceiver>
+            //</tns:Transport>
+
+            var transportReceiverNode = (from t in partyInfo.Elements(NameSpace + "Transport")
+                     where t.Attribute(NameSpace + "transportId").Value.Equals(transportId)
+                     select t.Element(NameSpace + "TransportReceiver")).FirstOrDefault();
+            if (transportReceiverNode == null) throw new InvalidOperationException("TransportReceiver is null");
+
+            var packageId = thisPartyActionBinding.Attribute(NameSpace + "packageId")?.Value;
+
+            var message = new CollaborationProtocolMessage
+            {
+                Name = messageFunction.ToUpper(),
+                Action = thisPartyActionBinding.Attribute(NameSpace + "action").Value,
+                DeliveryChannel = transportReceiverNode.Element(NameSpace + "Endpoint")?.Attribute(NameSpace + "uri")?.Value,
+                DeliveryProtocol = ParseDeliveryProtocol(transportReceiverNode.Element(NameSpace + "TransportProtocol")?.Value),
+                Parts = FindMessageParts(packageId, partyInfo)
+            };
+            return message;
+        }
+
+        private static DeliveryProtocol ParseDeliveryProtocol(string value)
+        {
+            switch (value)
+            {
+                case "AMQP":
+                    return DeliveryProtocol.Amqp;
+                default:
+                    return DeliveryProtocol.Unknown;
+            }
+        }
+
+        private static IEnumerable<CollaborationProtocolMessagePart> FindMessageParts(string packageId, XObject partyInfo)
+        {
+            if (partyInfo == null) throw new ArgumentNullException(nameof(partyInfo));
+
+            //<tns:Packaging tns:id="package_dialogmld_v1p1">
+            //	<tns:ProcessingCapabilities tns:parse="true" tns:generate="true" />
+            //	<tns:CompositeList>
+            //		<tns:Encapsulation tns:id="enc_dialogmld_v1p1" tns:mimetype="application/pkcs7-mime" tns:mimeparameters="smime-type=&quot;enveloped-data&quot;">
+            //			<tns:Constituent tns:idref="message_dialogmld_v1p1" />
+            //		</tns:Encapsulation>
+            //		<tns:Composite tns:id="request_msg_dialogmld_v1p1" tns:mimetype="multipart/related" tns:mimeparameters="type=text/xml">
+            //			<tns:Constituent tns:idref="enc_dialogmld_v1p1" />
+            //		</tns:Composite>
+            //	</tns:CompositeList>
+            //</tns:Packaging>
+
+            if (partyInfo.Parent == null) throw new InvalidOperationException("Cannot determine parent for partyInfo");
+
+            var packagingNode = (from p in partyInfo.Parent.Elements(NameSpace + "Packaging")
+                             where p.Attribute(NameSpace + "id").Value.Equals(packageId)
+                             select p).FirstOrDefault();
+
+            var compositeListNode = packagingNode?.Element(NameSpace + "CompositeList");
+            if (compositeListNode == null) return null;
+
+            var constituents = compositeListNode.Elements(NameSpace + "Encapsulation").Elements(NameSpace + "Constituent").ToList();
+            constituents.AddRange(compositeListNode.Elements(NameSpace + "Composite").Elements(NameSpace + "Constituent"));
+            if (!constituents.Any()) return null;
+
+            var parts = new List<CollaborationProtocolMessagePart>();
+
+            foreach (var constituent in constituents)
+            {
+                var simplePartId = constituent.Attribute(NameSpace + "idref").Value;
+                var min = (constituent.Attribute(NameSpace + "minOccurs") == null) ? 0 : constituent.Attribute(NameSpace + "minOccurs").Value.ToInt(0);
+                var max = (constituent.Attribute(NameSpace + "maxOccurs") == null) ? 1 : constituent.Attribute(NameSpace + "maxOccurs").Value.ToInt(1);
+
+                var simpleParts = from sp in partyInfo.Parent.Elements(NameSpace + "SimplePart")
+                        where sp.Attribute(NameSpace + "id").Value.Equals(simplePartId)
+                        select sp;
+
+                foreach (var part in simpleParts)
+                {
+                    parts.AddRange(part.Elements(NameSpace + "NamespaceSupported").Select(namespaceSupported => new CollaborationProtocolMessagePart()
+                    {
+                        XmlNamespace = namespaceSupported.Value,
+                        XmlSchema = namespaceSupported.Attribute(NameSpace + "location").Value,
+                        MinOccurrence = min,
+                        MaxOccurrence = max
+                    }));
+                }
+            }
+            return parts;
+        }
+
         /// <summary>
         /// Name of message function. i.e. DIALOG_INNBYGGER_KOORDINATOR
         /// </summary>

--- a/src/Helsenorge.Registries/CollaborationProtocolRegistry.cs
+++ b/src/Helsenorge.Registries/CollaborationProtocolRegistry.cs
@@ -1,5 +1,5 @@
 /* 
- * Copyright (c) 2020-2022, Norsk Helsenett SF and contributors
+ * Copyright (c) 2020-2023, Norsk Helsenett SF and contributors
  * See the file CONTRIBUTORS for details.
  * 
  * This file is licensed under the MIT license
@@ -9,7 +9,6 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Globalization;
 using System.Linq;
 using System.Security.Cryptography.X509Certificates;
 using System.ServiceModel;
@@ -126,7 +125,7 @@ namespace Helsenorge.Registries
             else
             {
                 var doc = XDocument.Parse(xmlString);
-                result = doc.Root == null ? null : MapFrompartyInfo(doc.Root.Element(_ns + "PartyInfo"));
+                result = doc.Root == null ? null : CollaborationProtocolProfile.CreateFromPartyInfoElement(doc.Root.Element(_ns + "PartyInfo"));
             }
 
             await CacheExtensions.WriteValueToCache(logger, _cache, key, result, _settings.CachingInterval, _settings.CachingFormatter).ConfigureAwait(false);
@@ -203,7 +202,7 @@ namespace Helsenorge.Registries
                 where x.Value != _settings.MyHerId.ToString()
                 select x.Parent).First();
 
-            result = MapFrompartyInfo(node);
+            result = CollaborationProtocolProfile.CreateFromPartyInfoElement(node);
             result.CpaId = id;
 
             await CacheExtensions.WriteValueToCache(logger, _cache, key, result, _settings.CachingInterval, _settings.CachingFormatter).ConfigureAwait(false);
@@ -277,7 +276,7 @@ namespace Helsenorge.Registries
                         where x.Value != _settings.MyHerId.ToString()
                         select x.Parent).First();
 
-            result = MapFrompartyInfo(node);
+            result = CollaborationProtocolProfile.CreateFromPartyInfoElement(node);
             result.CpaId = Guid.Parse(doc.Root.Attribute(_ns + "cpaid").Value);
             
             await CacheExtensions.WriteValueToCache(logger, _cache, key, result, _settings.CachingInterval, _settings.CachingFormatter).ConfigureAwait(false);
@@ -336,7 +335,7 @@ namespace Helsenorge.Registries
                 return null;
 
             var document = XDocument.Parse(collaborationProtocolProfileXml);
-            result = document.Root == null ? null : MapFrompartyInfo(document.Root.Element(_ns + "PartyInfo"));
+            result = document.Root == null ? null : CollaborationProtocolProfile.CreateFromPartyInfoElement(document.Root.Element(_ns + "PartyInfo"));
             if (result != null)
                 result.CppId = id;
 
@@ -403,219 +402,5 @@ namespace Helsenorge.Registries
         [ExcludeFromCodeCoverage] // requires wire communication
         private Task<T> Invoke<T>(ILogger logger, Func<ICommunicationPartyService, Task<T>> action, string methodName)
             => _invoker.Execute(logger, action, methodName);
-
-        private CollaborationProtocolProfile MapFrompartyInfo(XElement partyInfo)
-        {
-            if (partyInfo == null) throw new ArgumentNullException(nameof(partyInfo));
-
-            var cpa = new CollaborationProtocolProfile
-            {
-                Roles = new List<CollaborationProtocolRole>(),
-                Name = partyInfo.Attribute(_ns + "partyName").Value,
-                HerId = ParseInt(partyInfo.Element(_ns + "PartyId").Value, 0)
-            };
-
-            foreach (var role in partyInfo.Elements(_ns + "CollaborationRole"))
-            {
-                cpa.Roles.Add(CreateFromCollaborationRole(role, partyInfo));
-            }
-
-            XNamespace xmlSig = "http://www.w3.org/2000/09/xmldsig#";
-            foreach (var certificateElement in partyInfo.Elements(_ns + "Certificate"))
-            {
-                var base64 = certificateElement.Descendants(xmlSig + "X509Certificate").First().Value;
-                var certificate = new X509Certificate2(Convert.FromBase64String(base64));
-
-                if (certificate.HasKeyUsage(X509KeyUsageFlags.KeyEncipherment))
-                {
-                    cpa.EncryptionCertificate = certificate;
-                }
-                else if (certificate.HasKeyUsage(X509KeyUsageFlags.NonRepudiation))
-                {
-                    cpa.SignatureCertificate = certificate;
-                }
-            }
-            return cpa;
-        }
-
-        private CollaborationProtocolRole CreateFromCollaborationRole(XContainer element, XElement partyInfo)
-        {
-            if (element == null) throw new ArgumentNullException(nameof(element));
-            if (partyInfo == null) throw new ArgumentNullException(nameof(partyInfo));
-
-             //<tns:CollaborationRole >
-             //	<tns:ProcessSpecification tns:name="Dialog_Innbygger_Ekonsultasjon" tns:version="1.1" xlink:type="simple" xlink:href="http://www.helsedirektoratet.no/processes/Dialog_Innbygger_Ekonsultasjon.xml" tns:uuid="FB6A0156-7EEA-4AE3-AED3-C3A15D916A1C" />
-             //	<tns:Role tns:name="DIALOG_INNBYGGER_EKONSULTASJONreceiver" xlink:type="simple" xlink:href="http://www.helsedirektoratet.no/processes#DIALOG_INNBYGGER_EKONSULTASJONreceiver" />
-             //	<tns:ApplicationCertificateRef tns:certId="enc" />
-             //	<tns:ServiceBinding>
-             //		<tns:Service tns:type="string">S-DIALOG_INNBYGGER_EKONSULTASJON</tns:Service>
-             //		<tns:CanSend />
-             //		<tns:CanSend />
-             //		<tns:CanReceive />
-             //		<tns:CanReceive />
-             //	</tns:ServiceBinding>
-             //</tns:CollaborationRole>
-
-            var role = new CollaborationProtocolRole
-            {
-                ReceiveMessages = new List<CollaborationProtocolMessage>(),
-                SendMessages = new List<CollaborationProtocolMessage>(),
-                RoleName = element.Element(_ns + "Role")?.Attribute(_ns + "name").Value
-             };
-
-            var processSpecification = new ProcessSpecification
-            {
-                Name = element.Element(_ns + "ProcessSpecification")?.Attribute(_ns + "name").Value,
-                VersionString = element.Element(_ns + "ProcessSpecification")?.Attribute(_ns + "version").Value
-            };
-            role.ProcessSpecification = processSpecification;
-
-            var serviceBinding = element.Element(_ns + "ServiceBinding");
-            if (serviceBinding == null) return role;
-
-            foreach (var item in serviceBinding.Elements(_ns + "CanSend"))
-            {
-                role.SendMessages.Add(CreateFromThisPartyActionBinding(item.Element(_ns + "ThisPartyActionBinding"), partyInfo, processSpecification.Name));
-            }
-            foreach (var item in serviceBinding.Elements(_ns + "CanReceive"))
-            {
-                role.ReceiveMessages.Add(CreateFromThisPartyActionBinding(item.Element(_ns + "ThisPartyActionBinding"), partyInfo, processSpecification.Name));
-            }
-            return role;
-        }
-        /// <summary>
-        /// Returns a <see cref="CollaborationProtocolMessage"/> from a ThisPartyActionBinding XML element.
-        /// </summary>
-        /// <param name="thisPartyActionBinding">The ThisPartyActionBinding XML element.</param>
-        /// <param name="partyInfo">The PartyInfo XML node.</param>
-        /// <param name="messageFunction">The message function this <see cref="CollaborationProtocolMessage"/> represents.</param>
-        /// <returns></returns>
-        /// <example>
-        /// <![CDATA[
-        ///		<tns:ThisPartyActionBinding tns:id="Dialog_Innbygger_Ekonsultasjon-v1p1-DIALOG_INNBYGGER_EKONSULTASJONreceiver-Receive-APPREC-v1p1" tns:action="APPREC" tns:packageId="package_apprec_v1p1" xlink:type="simple">
-        ///			<tns:BusinessTransactionCharacteristics tns:isNonRepudiationRequired="true" tns:isNonRepudiationReceiptRequired="true" tns:isConfidential="none" tns:isAuthenticated="none" tns:isTamperProof="none" tns:isAuthorizationRequired="false" tns:isIntelligibleCheckRequired="false" tns:timeToPerform="P180M" />
-        ///			<tns:ChannelId>AMQPAsync_81b6cff2-7f96-4bae-b314-d70f7b0e1d62</tns:ChannelId>
-        ///		</tns:ThisPartyActionBinding>
-        /// ]]>
-        /// </example>
-        private CollaborationProtocolMessage CreateFromThisPartyActionBinding(XElement thisPartyActionBinding, XContainer partyInfo, string messageFunction)
-        {
-            if (thisPartyActionBinding == null) throw new ArgumentNullException(nameof(thisPartyActionBinding));
-            if (partyInfo == null) throw new ArgumentNullException(nameof(partyInfo));
-
-            //	<tns:ThisPartyActionBinding tns:id="Dialog_Innbygger_Ekonsultasjon-v1p1-DIALOG_INNBYGGER_EKONSULTASJONreceiver-Receive-APPREC-v1p1" tns:action="APPREC" tns:packageId="package_apprec_v1p1" xlink:type="simple">
-            //		<tns:BusinessTransactionCharacteristics tns:isNonRepudiationRequired="true" tns:isNonRepudiationReceiptRequired="true" tns:isConfidential="none" tns:isAuthenticated="none" tns:isTamperProof="none" tns:isAuthorizationRequired="false" tns:isIntelligibleCheckRequired="false" tns:timeToPerform="P180M" />
-            //		<tns:ChannelId>AMQPAsync_81b6cff2-7f96-4bae-b314-d70f7b0e1d62</tns:ChannelId>
-            //	</tns:ThisPartyActionBinding>
-            var channelIdNode = thisPartyActionBinding.Element(_ns + "ChannelId");
-            if (channelIdNode == null) throw new InvalidOperationException("ChannelId node is empty");
-
-            //<tns:DeliveryChannel tns:channelId="AMQPAsync_81b6cff2-7f96-4bae-b314-d70f7b0e1d62" tns:transportId="transport_0_1" tns:docExchangeId="docexchange_async_amqp">
-            //		<tns:MessagingCharacteristics />
-            // </tns:DeliveryChannel>
-
-            var transportId = (from c in partyInfo.Elements(_ns + "DeliveryChannel")
-                    where c.Attribute(_ns + "channelId").Value.Equals(channelIdNode.Value)
-                    select c.Attribute(_ns + "transportId").Value).FirstOrDefault();
-            if (transportId == null) throw new InvalidOperationException("TransportId is empty");
-
-            // <tns:Transport tns:transportId="transport_0_1">
-            //	<tns:TransportSender>
-            //		<tns:TransportProtocol tns:version="1.0">AMQP</tns:TransportProtocol>
-            //	</tns:TransportSender>
-            //	<tns:TransportReceiver>
-            //		<tns:TransportProtocol tns:version="1.0">AMQP</tns:TransportProtocol>
-            //		<tns:Endpoint tns:uri="sb.test.nhn.no/DigitalDialog/93238_async" />
-            //	</tns:TransportReceiver>
-            //</tns:Transport>
-
-            var transportReceiverNode = (from t in partyInfo.Elements(_ns + "Transport")
-                     where t.Attribute(_ns + "transportId").Value.Equals(transportId)
-                     select t.Element(_ns + "TransportReceiver")).FirstOrDefault();//.Element(_ns + "Endpoint").Attribute(_ns + "uri").Value;
-            if (transportReceiverNode == null) throw new InvalidOperationException("TransportReceiver is null");
-
-            var packageId = thisPartyActionBinding.Attribute(_ns + "packageId")?.Value;
-
-            var message = new CollaborationProtocolMessage
-            {
-                Name = messageFunction.ToUpper(),
-                Action = thisPartyActionBinding.Attribute(_ns + "action").Value,
-                DeliveryChannel = transportReceiverNode.Element(_ns + "Endpoint")?.Attribute(_ns + "uri")?.Value,
-                DeliveryProtocol = ParseDeliveryProtocol(transportReceiverNode.Element(_ns + "TransportProtocol")?.Value),
-                Parts = FindMessageParts(packageId, partyInfo)
-            };
-            return message;
-        }
-
-        private static DeliveryProtocol ParseDeliveryProtocol(string value)
-        {
-            switch (value)
-            {
-                case "AMQP":
-                    return DeliveryProtocol.Amqp;
-                default:
-                    return DeliveryProtocol.Unknown;
-            }
-        }
-        private IEnumerable<CollaborationProtocolMessagePart> FindMessageParts(string packageId, XObject partyInfo)
-        {
-            if (partyInfo == null) throw new ArgumentNullException(nameof(partyInfo));
-
-            //<tns:Packaging tns:id="package_dialogmld_v1p1">
-            //	<tns:ProcessingCapabilities tns:parse="true" tns:generate="true" />
-            //	<tns:CompositeList>
-            //		<tns:Encapsulation tns:id="enc_dialogmld_v1p1" tns:mimetype="application/pkcs7-mime" tns:mimeparameters="smime-type=&quot;enveloped-data&quot;">
-            //			<tns:Constituent tns:idref="message_dialogmld_v1p1" />
-            //		</tns:Encapsulation>
-            //		<tns:Composite tns:id="request_msg_dialogmld_v1p1" tns:mimetype="multipart/related" tns:mimeparameters="type=text/xml">
-            //			<tns:Constituent tns:idref="enc_dialogmld_v1p1" />
-            //		</tns:Composite>
-            //	</tns:CompositeList>
-            //</tns:Packaging>
-
-            if (partyInfo.Parent == null) throw new InvalidOperationException("Cannot determine parent for partyInfo");
-        
-            var packagingNode = (from p in partyInfo.Parent.Elements(_ns + "Packaging")
-                             where p.Attribute(_ns + "id").Value.Equals(packageId)
-                             select p).FirstOrDefault();
-
-            var compositeListNode = packagingNode?.Element(_ns + "CompositeList");
-            if (compositeListNode == null) return null;
-
-            var constituents = compositeListNode.Elements(_ns + "Encapsulation").Elements(_ns + "Constituent").ToList();
-            constituents.AddRange(compositeListNode.Elements(_ns + "Composite").Elements(_ns + "Constituent"));
-            if (!constituents.Any()) return null;
-
-            var parts = new List<CollaborationProtocolMessagePart>();
-
-            foreach (var constituent in constituents)
-            {
-                var simplePartId = constituent.Attribute(_ns + "idref").Value;
-                var min = (constituent.Attribute(_ns + "minOccurs") == null) ? 0 : ParseInt(constituent.Attribute(_ns + "minOccurs").Value, 0);
-                var max = (constituent.Attribute(_ns + "maxOccurs") == null) ? 1 : ParseInt(constituent.Attribute(_ns + "maxOccurs").Value, 1);
-
-                var simpleParts = from sp in partyInfo.Parent.Elements(_ns + "SimplePart")
-                        where sp.Attribute(_ns + "id").Value.Equals(simplePartId)
-                        select sp;
-
-                foreach (var part in simpleParts)
-                {
-                    parts.AddRange(part.Elements(_ns + "NamespaceSupported").Select(namespaceSupported => new CollaborationProtocolMessagePart()
-                    {
-                        XmlNamespace = namespaceSupported.Value,
-                        XmlSchema = namespaceSupported.Attribute(_ns + "location").Value,
-                        MinOccurrence = min,
-                        MaxOccurrence = max
-                    }));
-                }
-            }
-            return parts;
-        }
-
-        private static int ParseInt(string value, int defaultValue)
-        {
-            int i;
-            return int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out i) == false ? defaultValue : i;
-        }
     }
 }

--- a/src/Helsenorge.Registries/Utilities/StringExtensions.cs
+++ b/src/Helsenorge.Registries/Utilities/StringExtensions.cs
@@ -1,0 +1,21 @@
+﻿/*
+ * Copyright (c) 2023, Norsk Helsenett SF and contributors
+ * See the file CONTRIBUTORS for details.
+ *
+ * This file is licensed under the MIT license
+ * available at https://raw.githubusercontent.com/helsenorge/Helsenorge.Messaging/master/LICENSE
+ */
+
+using System.Globalization;
+
+namespace Helsenorge.Registries.Utilities;
+
+public static class StringExtensions
+{
+    public static int ToInt(this string value, int defaultValue = 0)
+    {
+        return int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var i)
+            ? i
+            : defaultValue;
+    }
+}


### PR DESCRIPTION
This moves the helper methods in `CollaborationProtocolRegistry` out into `CollaborationProtocol{Message,Profile,Role}` and  rebrands them as factory methods.