### PR TITLE
Registries+Messaging: Add support for skipping CPA resolve

### DIFF
--- a/src/Helsenorge.Messaging/MessagingClient.cs
+++ b/src/Helsenorge.Messaging/MessagingClient.cs
@@ -14,6 +14,7 @@ using Helsenorge.Messaging.ServiceBus.Senders;
 using Helsenorge.Registries.Abstractions;
 using Microsoft.Extensions.Logging;
 using System.Collections.Generic;
+using Helsenorge.Registries;
 
 namespace Helsenorge.Messaging
 {
@@ -288,6 +289,12 @@ namespace Helsenorge.Messaging
 
         private async Task<CollaborationProtocolProfile> FindProfile(ILogger logger, OutgoingMessage message)
         {
+            if (Settings.MessageFunctionsExcludedFromCpaResolve.Contains(message.MessageFunction))
+            {
+                // MessageFunction is defined in exception list, return a dummy CollaborationProtocolProfile
+                return await DummyCollaborationProtocolProfileFactory.CreateAsync(AddressRegistry, logger, message.ToHerId, message.MessageFunction);
+            }
+
             var profile = 
                 await CollaborationProtocolRegistry.FindAgreementForCounterpartyAsync(logger, message.ToHerId).ConfigureAwait(false) ??
                 await CollaborationProtocolRegistry.FindProtocolForCounterpartyAsync(logger, message.ToHerId).ConfigureAwait(false);

--- a/src/Helsenorge.Messaging/MessagingClient.cs
+++ b/src/Helsenorge.Messaging/MessagingClient.cs
@@ -243,7 +243,7 @@ namespace Helsenorge.Messaging
             var profile = await FindProfile(logger, message).ConfigureAwait(false);
             var collaborationProtocolMessage = profile?.FindMessageForReceiver(messageFunction);
 
-            if ((profile != null && profile.Name == Registries.CollaborationProtocolRegistry.DummyPartyName)
+            if ((profile != null && profile.Name == Registries.DummyCollaborationProtocolProfileFactory.DummyPartyName)
                 || (collaborationProtocolMessage == null && messageFunction.ToUpper().Contains("DIALOG_INNBYGGER_TIMERESERVASJON")))
             {
                 // HACK: This whole section inside this if statement is a hack to support communication parties which do not have the process DIALOG_INNBYGGER_TIMERESERVASJON configured.

--- a/src/Helsenorge.Messaging/MessagingSettings.cs
+++ b/src/Helsenorge.Messaging/MessagingSettings.cs
@@ -58,6 +58,11 @@ namespace Helsenorge.Messaging
         public IDictionary<string, object> ApplicationProperties { get; } = new Dictionary<string, object>();
 
         /// <summary>
+        /// Skip CPA lookup for message functions in this list. Instead use an internal dummy CPA.
+        /// </summary>
+        public List<string> MessageFunctionsExcludedFromCpaResolve { get; set; } = new List<string>();
+
+        /// <summary>
         /// Specifies the encryption type used in messaging
         /// </summary>
         [Obsolete("SHOULD NOT BE USED BY ANYONE EXCEPT HELSENORGE. Temporary config to allow for TripleDES encryption")]

--- a/src/Helsenorge.Messaging/ServiceBus/Receivers/MessageListener.cs
+++ b/src/Helsenorge.Messaging/ServiceBus/Receivers/MessageListener.cs
@@ -329,6 +329,11 @@ namespace Helsenorge.Messaging.ServiceBus.Receivers
 
         private async Task<CollaborationProtocolProfile> ResolveProfile(IMessagingMessage message)
         {
+            if(Core.MessagingSettings.MessageFunctionsExcludedFromCpaResolve.Contains(message.MessageFunction))
+            {
+                // MessageFunction is defined in exception list, return a dummy CollaborationProtocolProfile
+                return await DummyCollaborationProtocolProfileFactory.CreateAsync(Core.AddressRegistry, Logger, message.FromHerId, message.MessageFunction);
+            }
 
             // if we receive an error message then CPA isn't needed because we're not decrypting the message and then the CPA info isn't needed
             if (QueueType == QueueType.Error) return null;

--- a/src/Helsenorge.Messaging/ServiceBus/ServiceBusCore.cs
+++ b/src/Helsenorge.Messaging/ServiceBus/ServiceBusCore.cs
@@ -55,6 +55,7 @@ namespace Helsenorge.Messaging.ServiceBus
 
         //convencience properties
         internal ServiceBusSettings Settings => Core.Settings.ServiceBus;
+        internal MessagingSettings MessagingSettings => Core.Settings;
         internal IAddressRegistry AddressRegistry => Core.AddressRegistry;
         internal ICollaborationProtocolRegistry CollaborationProtocolRegistry => Core.CollaborationProtocolRegistry;
         internal ICertificateValidator CertificateValidator => Core.CertificateValidator;

--- a/src/Helsenorge.Messaging/ServiceBus/ServiceBusCore.cs
+++ b/src/Helsenorge.Messaging/ServiceBus/ServiceBusCore.cs
@@ -135,7 +135,6 @@ namespace Helsenorge.Messaging.ServiceBus
 
             logger.LogStartSend(queueType, outgoingMessage.MessageFunction, Core.Settings.MyHerId, outgoingMessage.ToHerId, outgoingMessage.MessageId, $"Sending message using host and queue: {HostnameAndPath}/{queueName}", outgoingMessage.Payload);
 
-            var hasAgreement = true;
             // first we try and find an agreement
             var profile = await FindProfile(logger, outgoingMessage);
             var stopwatch = new Stopwatch();
@@ -230,10 +229,11 @@ namespace Helsenorge.Messaging.ServiceBus
             messagingMessage.ToHerId = outgoingMessage.ToHerId;
             messagingMessage.ApplicationTimestamp = DateTime.Now;
 
-            if (hasAgreement)
+            if(profile.CpaId != Guid.Empty)
             {
                 messagingMessage.CpaId = profile.CpaId.ToString("D");
             }
+
             await Send(logger, messagingMessage).ConfigureAwait(false);
 
             logger.LogEndSend(queueType, messagingMessage.MessageFunction, messagingMessage.FromHerId, messagingMessage.ToHerId, messagingMessage.MessageId);

--- a/src/Helsenorge.Registries/CollaborationProtocolRegistry.cs
+++ b/src/Helsenorge.Registries/CollaborationProtocolRegistry.cs
@@ -31,14 +31,6 @@ namespace Helsenorge.Registries
     {
         XNamespace _ns = "http://www.oasis-open.org/committees/ebxml-cppa/schema/cpp-cpa-2_0.xsd";
 
-        /// <summary>
-        /// A constant that is used to indicate a Dummy Collaboration Protocol Profile (CPP) in case the Communication Party completely lacks a CPP.
-        /// </summary>
-        /// <remarks>
-        /// This will be removed in a future version without warning, since lacking a CPP is not considered good or acceptable practice
-        /// </remarks>
-        public const string DummyPartyName = "DummyCollaborationProtocolProfile";
-
         private readonly SoapServiceInvoker _invoker;
         private readonly CollaborationProtocolRegistrySettings _settings;
         private readonly IDistributedCache _cache;
@@ -114,14 +106,7 @@ namespace Helsenorge.Registries
             }
             if (string.IsNullOrEmpty(xmlString))
             {
-                // HACK: This whole thing is a hack and should be removed.
-                var communicationParty = await _adressRegistry.FindCommunicationPartyDetailsAsync(logger, counterpartyHerId).ConfigureAwait(false);
-                // HACK: We are assuming that we should return the asynchronous queue name as the delivery channel.
-                var deliveryChannel = communicationParty.AsynchronousQueueName;
-                result = CreateDummyCollaborationProtocolProfile(counterpartyHerId,
-                    await _adressRegistry.GetCertificateDetailsForEncryptionAsync(logger, counterpartyHerId).ConfigureAwait(false),
-                    await _adressRegistry.GetCertificateDetailsForValidatingSignatureAsync(logger, counterpartyHerId).ConfigureAwait(false),
-                    deliveryChannel);
+                return await DummyCollaborationProtocolProfileFactory.CreateAsync(_adressRegistry, logger, counterpartyHerId, null);
             }
             else
             {
@@ -348,44 +333,6 @@ namespace Helsenorge.Registries
         protected virtual Task<string> GetCollaborationProtocolProfileAsXmlAsyncInternal(ILogger logger, Guid id)
             => Invoke(logger, x => x.GetCppXmlAsync(id), "GetCppXmlAsync");
         
-        // HACK: This is a hack used for when interns and substitues which do not have CPP send a message on behalf of the GP.
-        private CollaborationProtocolProfile CreateDummyCollaborationProtocolProfile(int herId, Abstractions.CertificateDetails encryptionCertificate, Abstractions.CertificateDetails signatureCertificate, string deliveryChannel)
-        {
-            return new CollaborationProtocolProfile
-            {
-                Roles = new List<CollaborationProtocolRole>
-                {
-                    new CollaborationProtocolRole
-                    {
-                        ReceiveMessages = new List<CollaborationProtocolMessage>
-                        {
-                            new CollaborationProtocolMessage
-                            {
-                                Name = "APPREC",
-                                Action = "APPREC",
-                                DeliveryProtocol = DeliveryProtocol.Amqp,
-                                DeliveryChannel = deliveryChannel
-                            }
-                        },
-                        SendMessages = new List<CollaborationProtocolMessage>
-                        {
-                            new CollaborationProtocolMessage
-                            {
-                                Name = "APPREC",
-                                Action = "APPREC",
-                                DeliveryProtocol = DeliveryProtocol.Amqp,
-                                DeliveryChannel = deliveryChannel
-                            }
-                        }
-                    }
-                },
-                HerId = herId,
-                Name = DummyPartyName,
-                EncryptionCertificate = encryptionCertificate?.Certificate,
-                SignatureCertificate = signatureCertificate?.Certificate
-            };
-        }
-
         /// <summary>
         /// Makes the actual call to the registry. Virtual so that it can overriden by mocks.
         /// </summary>

--- a/src/Helsenorge.Registries/DummyCollaborationProtocolProfileFactory.cs
+++ b/src/Helsenorge.Registries/DummyCollaborationProtocolProfileFactory.cs
@@ -27,6 +27,7 @@ public static class DummyCollaborationProtocolProfileFactory
     /// </remarks>
     public const string DummyPartyName = "DummyCollaborationProtocolProfile";
 
+    private const string MessageFunctionExceptionProfileName = "MessageFunctionExceptionProfile";
 
     public static async Task<CollaborationProtocolProfile> CreateAsync(IAddressRegistry addressRegistry, ILogger logger, int herId, string messageFunction)
     {
@@ -76,7 +77,7 @@ public static class DummyCollaborationProtocolProfileFactory
                 }
             },
             HerId = herId,
-            Name = DummyPartyName,
+            Name = messageFunction != null ? MessageFunctionExceptionProfileName : DummyPartyName,
             EncryptionCertificate = encryptionCertificate?.Certificate,
             SignatureCertificate = signatureCertificate?.Certificate
         };

--- a/src/Helsenorge.Registries/DummyCollaborationProtocolProfileFactory.cs
+++ b/src/Helsenorge.Registries/DummyCollaborationProtocolProfileFactory.cs
@@ -1,0 +1,84 @@
+/* 
+ * Copyright (c) 2020-2022, Norsk Helsenett SF and contributors
+ * See the file CONTRIBUTORS for details.
+ * 
+ * This file is licensed under the MIT license
+ * available at https://raw.githubusercontent.com/helsenorge/Helsenorge.Messaging/master/LICENSE
+ */
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Helsenorge.Registries.Abstractions;
+using Microsoft.Extensions.Logging;
+
+namespace Helsenorge.Registries;
+
+/// <summary>
+/// This is designed so it can be used as a singleton
+/// </summary>
+public static class DummyCollaborationProtocolProfileFactory
+{
+
+    /// <summary>
+    /// A constant that is used to indicate a Dummy Collaboration Protocol Profile (CPP) in case the Communication Party completely lacks a CPP.
+    /// </summary>
+    /// <remarks>
+    /// This will be removed in a future version without warning, since lacking a CPP is not considered good or acceptable practice
+    /// </remarks>
+    public const string DummyPartyName = "DummyCollaborationProtocolProfile";
+
+
+    public static async Task<CollaborationProtocolProfile> CreateAsync(IAddressRegistry addressRegistry, ILogger logger, int herId, string messageFunction)
+    {
+        var communicationParty = await addressRegistry.FindCommunicationPartyDetailsAsync(logger, herId).ConfigureAwait(false);
+        if(communicationParty == null)
+        {
+            logger.LogWarning($"Could not get communication party details for HerId {herId}");
+            return null;
+        }
+
+        var deliveryChannel = communicationParty.AsynchronousQueueName;
+        return CreateDummyCollaborationProtocolProfile(herId,
+            await addressRegistry.GetCertificateDetailsForEncryptionAsync(logger, herId).ConfigureAwait(false),
+            await addressRegistry.GetCertificateDetailsForValidatingSignatureAsync(logger, herId).ConfigureAwait(false),
+            deliveryChannel,
+            messageFunction);
+    }
+
+    private static CollaborationProtocolProfile CreateDummyCollaborationProtocolProfile(int herId, CertificateDetails encryptionCertificate, CertificateDetails signatureCertificate, string deliveryChannel, string messageFunction)
+    {
+        return new CollaborationProtocolProfile
+        {
+            Roles = new List<CollaborationProtocolRole>
+            {
+                new CollaborationProtocolRole
+                {
+                    ReceiveMessages = new List<CollaborationProtocolMessage>
+                    {
+                        new CollaborationProtocolMessage
+                        {
+                            Name = messageFunction ?? "APPREC",
+                            Action = messageFunction ?? "APPREC",
+                            DeliveryProtocol = DeliveryProtocol.Amqp,
+                            DeliveryChannel = deliveryChannel
+                        }
+                    },
+                    SendMessages = new List<CollaborationProtocolMessage>
+                    {
+                        new CollaborationProtocolMessage
+                        {
+                            Name = messageFunction ?? "APPREC",
+                            Action = messageFunction ?? "APPREC",
+                            DeliveryProtocol = DeliveryProtocol.Amqp,
+                            DeliveryChannel = deliveryChannel
+                        }
+                    }
+                }
+            },
+            HerId = herId,
+            Name = DummyPartyName,
+            EncryptionCertificate = encryptionCertificate?.Certificate,
+            SignatureCertificate = signatureCertificate?.Certificate
+        };
+    }
+}

--- a/test/Helsenorge.Registries.Tests/CollaborationRegistryTests.cs
+++ b/test/Helsenorge.Registries.Tests/CollaborationRegistryTests.cs
@@ -7,6 +7,7 @@
  */
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Security.Cryptography;
@@ -27,6 +28,7 @@ namespace Helsenorge.Registries.Tests
     public class CollaborationRegistryTests
     {
         private CollaborationProtocolRegistryMock _registry;
+        private IAddressRegistry _addressRegistry;
         private ILoggerFactory _loggerFactory;
         private ILogger _logger;
 
@@ -52,8 +54,8 @@ namespace Helsenorge.Registries.Tests
 
             var distributedCache = DistributedCacheFactory.Create();
 
-            IAddressRegistry addressRegistry = AddressRegistryTests.GetDefaultAddressRegistryMock();
-            _registry = new CollaborationProtocolRegistryMock(settings, distributedCache, addressRegistry);
+            _addressRegistry = AddressRegistryTests.GetDefaultAddressRegistryMock();
+            _registry = new CollaborationProtocolRegistryMock(settings, distributedCache, _addressRegistry);
             _registry.SetupFindAgreementById(i =>
             {
                 var file = TestFileUtility.GetFullPathToFile(Path.Combine("Files", $"CPA_{i:D}.xml"));
@@ -142,6 +144,16 @@ namespace Helsenorge.Registries.Tests
             var profile = _registry.FindProtocolForCounterpartyAsync(_logger, 93252).Result;
             Assert.IsNotNull(profile);
             Assert.AreEqual("DummyCollaborationProtocolProfile", profile.Name);
+        }
+
+        [TestMethod]
+        public void Read_DummyCollaborationProfile_Found()
+        {
+            var profile = DummyCollaborationProtocolProfileFactory.CreateAsync(_addressRegistry, _logger, 93238, "NO_CPA_MESSAGE").Result;
+            Assert.IsNotNull(profile);
+            Assert.AreEqual("DummyCollaborationProtocolProfile", profile.Name);
+            Assert.AreEqual("NO_CPA_MESSAGE", profile.Roles.First().SendMessages.First().Name);
+            Assert.AreEqual("NO_CPA_MESSAGE", profile.Roles.First().SendMessages.First().Action);
         }
 
         [TestMethod, Ignore]

--- a/test/Helsenorge.Registries.Tests/CollaborationRegistryTests.cs
+++ b/test/Helsenorge.Registries.Tests/CollaborationRegistryTests.cs
@@ -151,7 +151,7 @@ namespace Helsenorge.Registries.Tests
         {
             var profile = DummyCollaborationProtocolProfileFactory.CreateAsync(_addressRegistry, _logger, 93238, "NO_CPA_MESSAGE").Result;
             Assert.IsNotNull(profile);
-            Assert.AreEqual("DummyCollaborationProtocolProfile", profile.Name);
+            Assert.AreEqual("MessageFunctionExceptionProfile", profile.Name);
             Assert.AreEqual("NO_CPA_MESSAGE", profile.Roles.First().SendMessages.First().Name);
             Assert.AreEqual("NO_CPA_MESSAGE", profile.Roles.First().SendMessages.First().Action);
         }

--- a/test/Helsenorge.Registries.Tests/Files/CommunicationDetails_93238.xml
+++ b/test/Helsenorge.Registries.Tests/Files/CommunicationDetails_93238.xml
@@ -1,0 +1,215 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<CommunicationParty i:type="OrganizationPerson" xmlns="http://register.nhn.no/CommunicationParty" xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+    <Active>true</Active>
+    <DisplayName>Alexander Dahl</DisplayName>
+    <ElectronicAddresses xmlns:a="http://register.nhn.no/Common">
+        <a:ElectronicAddress>
+            <a:Address>sb.test.nhn.no/DigitalDialog/93238_async</a:Address>
+            <a:Inherited>false</a:Inherited>
+            <a:LastChanged>2015-05-18T10:44:06.663</a:LastChanged>
+            <a:Type>
+                <a:Active>true</a:Active>
+                <a:CodeText>Asynkron AMQP kø</a:CodeText>
+                <a:CodeValue>E_SB_ASYNC</a:CodeValue>
+                <a:OID>9044</a:OID>
+                <a:SimpleType>type_adressekomponeneter</a:SimpleType>
+            </a:Type>
+            <a:TypeCodeValue>E_SB_ASYNC</a:TypeCodeValue>
+        </a:ElectronicAddress>
+        <a:ElectronicAddress>
+            <a:Address>sb.test.nhn.no/DigitalDialog/93238_error</a:Address>
+            <a:Inherited>false</a:Inherited>
+            <a:LastChanged>2015-05-18T10:44:06.663</a:LastChanged>
+            <a:Type>
+                <a:Active>true</a:Active>
+                <a:CodeText>Feilmelding AMQP kø</a:CodeText>
+                <a:CodeValue>E_SB_ERROR</a:CodeValue>
+                <a:OID>9044</a:OID>
+                <a:SimpleType>type_adressekomponeneter</a:SimpleType>
+            </a:Type>
+            <a:TypeCodeValue>E_SB_ERROR</a:TypeCodeValue>
+        </a:ElectronicAddress>
+        <a:ElectronicAddress>
+            <a:Address>sb.test.nhn.no/DigitalDialog/93238_sync</a:Address>
+            <a:Inherited>false</a:Inherited>
+            <a:LastChanged>2015-05-18T10:44:06.663</a:LastChanged>
+            <a:Type>
+                <a:Active>true</a:Active>
+                <a:CodeText>Synkron AMQP kø</a:CodeText>
+                <a:CodeValue>E_SB_SYNC</a:CodeValue>
+                <a:OID>9044</a:OID>
+                <a:SimpleType>type_adressekomponeneter</a:SimpleType>
+            </a:Type>
+            <a:TypeCodeValue>E_SB_SYNC</a:TypeCodeValue>
+        </a:ElectronicAddress>
+        <a:ElectronicAddress>
+            <a:Address>ldap://ldap.test4.buypass.no/dc=Buypass,dc=NO,CN=Buypass%20Class%203%20Test4%20CA%203?usercertificate;binary?sub?(&amp;(sn=983544622)(cn=TEST - DDFL))</a:Address>
+            <a:Inherited>true</a:Inherited>
+            <a:LastChanged>2015-05-18T10:44:12.4</a:LastChanged>
+            <a:Type>
+                <a:Active>true</a:Active>
+                <a:CodeText>Digital sertifikat</a:CodeText>
+                <a:CodeValue>E_DS</a:CodeValue>
+                <a:OID>9044</a:OID>
+                <a:SimpleType>type_adressekomponeneter</a:SimpleType>
+            </a:Type>
+            <a:TypeCodeValue>E_DS</a:TypeCodeValue>
+        </a:ElectronicAddress>
+    </ElectronicAddresses>
+    <HerId>93238</HerId>
+    <IsValidCommunicationParty>true</IsValidCommunicationParty>
+    <LastChanged>2015-05-18T10:41:04.557</LastChanged>
+    <Municipality xmlns:a="http://register.nhn.no/Common">
+        <a:Active>true</a:Active>
+        <a:CodeText>OSLO</a:CodeText>
+        <a:CodeValue>301</a:CodeValue>
+        <a:OID>3402</a:OID>
+        <a:SimpleType>kommunenummer</a:SimpleType>
+    </Municipality>
+    <Name>Alexander Dahl</Name>
+    <ParentBusinessType xmlns:a="http://register.nhn.no/Common">
+        <a:Active>true</a:Active>
+        <a:CodeText>Privatpraktiserende autorisert helsepersonell</a:CodeText>
+        <a:CodeValue>103</a:CodeValue>
+        <a:OID>9040</a:OID>
+        <a:SimpleType>helsevirksomhet_type</a:SimpleType>
+    </ParentBusinessType>
+    <ParentHerId>93237</ParentHerId>
+    <ParentName>DD fastlege UTV MUG</ParentName>
+    <ParentOrganizationNumber>999944999</ParentOrganizationNumber>
+    <PhysicalAddresses xmlns:a="http://register.nhn.no/Common"/>
+    <ServerTime>2016-06-02T08:42:59.3977016+02:00</ServerTime>
+    <Type>Person</Type>
+    <Valid xmlns:a="http://register.nhn.no/Common">
+        <a:From>2015-05-18T00:00:00</a:From>
+        <a:To>9999-12-31T00:00:00</a:To>
+    </Valid>
+    <Departments/>
+    <Organizations>
+        <Organization>
+            <Active>true</Active>
+            <DisplayName>DD fastlege UTV MUG</DisplayName>
+            <ElectronicAddresses xmlns:a="http://register.nhn.no/Common">
+                <a:ElectronicAddress>
+                    <a:Address>ldap://ldap.test4.buypass.no/dc=Buypass,dc=NO,CN=Buypass%20Class%203%20Test4%20CA%203?usercertificate;binary?sub?(&amp;(sn=983544622)(cn=TEST - DDFL))</a:Address>
+                    <a:Inherited>false</a:Inherited>
+                    <a:LastChanged>2015-05-18T10:44:12.4</a:LastChanged>
+                    <a:Type>
+                        <a:Active>true</a:Active>
+                        <a:CodeText>Digital sertifikat</a:CodeText>
+                        <a:CodeValue>E_DS</a:CodeValue>
+                        <a:OID>9044</a:OID>
+                        <a:SimpleType>type_adressekomponeneter</a:SimpleType>
+                    </a:Type>
+                    <a:TypeCodeValue>E_DS</a:TypeCodeValue>
+                </a:ElectronicAddress>
+            </ElectronicAddresses>
+            <HerId>93237</HerId>
+            <IsValidCommunicationParty>false</IsValidCommunicationParty>
+            <LastChanged>2015-10-07T21:45:16.1</LastChanged>
+            <Municipality xmlns:a="http://register.nhn.no/Common">
+                <a:Active>true</a:Active>
+                <a:CodeText>OSLO</a:CodeText>
+                <a:CodeValue>301</a:CodeValue>
+                <a:OID>3402</a:OID>
+                <a:SimpleType>kommunenummer</a:SimpleType>
+            </Municipality>
+            <Name>DD fastlege UTV MUG</Name>
+            <ParentBusinessType i:nil="true" xmlns:a="http://register.nhn.no/Common"/>
+            <ParentHerId>-1</ParentHerId>
+            <ParentName i:nil="true"/>
+            <ParentOrganizationNumber>-1</ParentOrganizationNumber>
+            <PhysicalAddresses xmlns:a="http://register.nhn.no/Common"/>
+            <ServerTime>2016-06-02T08:42:59.4602046+02:00</ServerTime>
+            <Type>Organization</Type>
+            <Valid xmlns:a="http://register.nhn.no/Common">
+                <a:From>1990-01-01T00:00:00</a:From>
+                <a:To>9999-12-31T23:59:59.997</a:To>
+            </Valid>
+            <BusinessType xmlns:a="http://register.nhn.no/Common">
+                <a:Active>true</a:Active>
+                <a:CodeText>Privatpraktiserende autorisert helsepersonell</a:CodeText>
+                <a:CodeValue>103</a:CodeValue>
+                <a:OID>9040</a:OID>
+                <a:SimpleType>helsevirksomhet_type</a:SimpleType>
+            </BusinessType>
+            <Departments/>
+            <IndustryCodes xmlns:a="http://register.nhn.no/Common"/>
+            <OrganizationNumber>999944999</OrganizationNumber>
+            <People/>
+            <Properties xmlns:a="http://register.nhn.no/Common"/>
+            <Services/>
+        </Organization>
+    </Organizations>
+    <Person xmlns:a="http://register.nhn.no/HPR">
+        <a:BirthDate>1939-06-06T00:00:00</a:BirthDate>
+        <a:CitizenId xmlns:b="http://register.nhn.no/Common">
+            <b:CitizenIdType>Invalid</b:CitizenIdType>
+            <b:Id/>
+            <b:Sex>
+                <b:Active>true</b:Active>
+                <b:CodeText>Ikke spesifisert</b:CodeText>
+                <b:CodeValue>9</b:CodeValue>
+                <b:OID>3101</b:OID>
+                <b:SimpleType>kjonn</b:SimpleType>
+            </b:Sex>
+        </a:CitizenId>
+        <a:FirstName>Alexander</a:FirstName>
+        <a:HPRInformation>
+            <a:Authorizations>
+                <a:Authorization>
+                    <a:LastChanged>2016-06-02T08:42:59.3977016</a:LastChanged>
+                    <a:Profession xmlns:b="http://register.nhn.no/Common">
+                        <b:Active>true</b:Active>
+                        <b:CodeText>Lege</b:CodeText>
+                        <b:CodeValue>LE</b:CodeValue>
+                        <b:OID>9060</b:OID>
+                        <b:SimpleType>kategori_helsepersonell</b:SimpleType>
+                    </a:Profession>
+                    <a:Requisition>
+                        <a:LastChanged>2016-06-02T08:42:59.3977016</a:LastChanged>
+                        <a:Type xmlns:b="http://register.nhn.no/Common">
+                            <b:Active>true</b:Active>
+                            <b:CodeText>Full rekvisisjonsrett</b:CodeText>
+                            <b:CodeValue>1</b:CodeValue>
+                            <b:OID>7701</b:OID>
+                            <b:SimpleType>helsepersonellregisterets_hpr_klassifikasjon_av_rekvisisjonsrett</b:SimpleType>
+                        </a:Type>
+                        <a:Valid xmlns:b="http://register.nhn.no/Common">
+                            <b:From>2004-04-20T00:00:00</b:From>
+                            <b:To>2040-04-20T00:00:00</b:To>
+                        </a:Valid>
+                    </a:Requisition>
+                    <a:Specialities/>
+                    <a:Type xmlns:b="http://register.nhn.no/Common">
+                        <b:Active>true</b:Active>
+                        <b:CodeText>Autorisasjon</b:CodeText>
+                        <b:CodeValue>1</b:CodeValue>
+                        <b:OID>7704</b:OID>
+                        <b:SimpleType>helsepersonellregisterets_hpr_klassifikasjon_av_autorisasjoner</b:SimpleType>
+                    </a:Type>
+                    <a:Valid xmlns:b="http://register.nhn.no/Common">
+                        <b:From>2004-04-20T00:00:00</b:From>
+                        <b:To>2040-04-20T00:00:00</b:To>
+                    </a:Valid>
+                </a:Authorization>
+            </a:Authorizations>
+            <a:HPRNo>1010037</a:HPRNo>
+            <a:HPRNumber>1010037</a:HPRNumber>
+            <a:LastChanged>2016-06-02T08:42:59.3977016</a:LastChanged>
+            <a:SpecialCompetences/>
+        </a:HPRInformation>
+        <a:LastChanged>2013-12-19T15:34:59.95</a:LastChanged>
+        <a:LastName>Dahl</a:LastName>
+        <a:MiddleName i:nil="true"/>
+        <a:Sex xmlns:b="http://register.nhn.no/Common">
+            <b:Active>true</b:Active>
+            <b:CodeText>Kvinne</b:CodeText>
+            <b:CodeValue>2</b:CodeValue>
+            <b:OID>3101</b:OID>
+            <b:SimpleType>kjonn</b:SimpleType>
+        </a:Sex>
+    </Person>
+    <Properties xmlns:a="http://register.nhn.no/Common"/>
+    <Title i:nil="true"/>
+</CommunicationParty>


### PR DESCRIPTION
This PR add suppport for sending/receiving messages without CPA resolve.
By adding message functions to MessageFunctionsExcludedFromCpaResolve list in MessagingSettings, CPA resolve will be skipped for those message functions. An dummy CPA will be used instead.
This will make it possible to use Helsenorge.Messaging for communication with both Helsenorge and other communication parties not using CPA.