### PR TITLE
Messaging: Do not include the user_id property when cloning message

### DIFF
--- a/src/Helsenorge.Messaging/ServiceBus/ServiceBusMessage.cs
+++ b/src/Helsenorge.Messaging/ServiceBus/ServiceBusMessage.cs
@@ -291,7 +291,6 @@ namespace Helsenorge.Messaging.ServiceBus
                     GroupSequence = _implementation.Properties.GroupSequence,
                     MessageId = _implementation.Properties.MessageId,
                     ReplyTo = _implementation.Properties.ReplyTo,
-                    UserId = _implementation.Properties.UserId,
                     AbsoluteExpiryTime = _implementation.Properties.AbsoluteExpiryTime,
                     ReplyToGroupId = _implementation.Properties.ReplyToGroupId,
                 };


### PR DESCRIPTION
Cloning the user_id property on a message sent to us by another user will cause RabbitMQ to reject the message.