### PR TITLE
Messaging+Registries: Fix message function exceptions for apprec

### DIFF
--- a/src/Helsenorge.Messaging/MessagingClient.cs
+++ b/src/Helsenorge.Messaging/MessagingClient.cs
@@ -244,7 +244,7 @@ namespace Helsenorge.Messaging
             var profile = await ServiceBus.FindProfile(logger, message).ConfigureAwait(false);
             var collaborationProtocolMessage = profile?.FindMessageForReceiver(messageFunction);
 
-            if ((profile != null && profile.Name == DummyCollaborationProtocolProfileFactory.DummyPartyName)
+            if ((profile != null && DummyCollaborationProtocolProfileFactory.IsDummyProfile(profile))
                 || (collaborationProtocolMessage == null && messageFunction.ToUpper().Contains("DIALOG_INNBYGGER_TIMERESERVASJON")))
             {
                 // HACK: This whole section inside this if statement is a hack to support communication parties which do not have the process DIALOG_INNBYGGER_TIMERESERVASJON configured.

--- a/src/Helsenorge.Messaging/ServiceBus/ServiceBusCore.cs
+++ b/src/Helsenorge.Messaging/ServiceBus/ServiceBusCore.cs
@@ -442,10 +442,14 @@ namespace Helsenorge.Messaging.ServiceBus
         /// <returns>CollaborationProtocolProfile</returns>
         public async Task<CollaborationProtocolProfile> FindProfile(ILogger logger, OutgoingMessage message)
         {
-            if (Core.Settings.MessageFunctionsExcludedFromCpaResolve.Contains(message.MessageFunction))
+            var messageFunction = string.IsNullOrEmpty(message.ReceiptForMessageFunction)
+                ? message.MessageFunction
+                : message.ReceiptForMessageFunction;
+
+            if (Core.Settings.MessageFunctionsExcludedFromCpaResolve.Contains(messageFunction))
             {
                 // MessageFunction is defined in exception list, return a dummy CollaborationProtocolProfile
-                return await DummyCollaborationProtocolProfileFactory.CreateAsync(AddressRegistry, logger, message.ToHerId, message.MessageFunction);
+                return await DummyCollaborationProtocolProfileFactory.CreateAsync(AddressRegistry, logger, message.ToHerId, messageFunction);
             }
 
             var profile =

--- a/src/Helsenorge.Registries/DummyCollaborationProtocolProfileFactory.cs
+++ b/src/Helsenorge.Registries/DummyCollaborationProtocolProfileFactory.cs
@@ -29,6 +29,8 @@ public static class DummyCollaborationProtocolProfileFactory
 
     private const string MessageFunctionExceptionProfileName = "MessageFunctionExceptionProfile";
 
+    public static bool IsDummyProfile(CollaborationProtocolProfile cpp) => cpp?.Name == DummyPartyName || cpp?.Name == MessageFunctionExceptionProfileName;
+
     public static async Task<CollaborationProtocolProfile> CreateAsync(IAddressRegistry addressRegistry, ILogger logger, int herId, string messageFunction)
     {
         var communicationParty = await addressRegistry.FindCommunicationPartyDetailsAsync(logger, herId).ConfigureAwait(false);

--- a/src/Helsenorge.Registries/DummyCollaborationProtocolProfileFactory.cs
+++ b/src/Helsenorge.Registries/DummyCollaborationProtocolProfileFactory.cs
@@ -25,7 +25,7 @@ public static class DummyCollaborationProtocolProfileFactory
     /// <remarks>
     /// This will be removed in a future version without warning, since lacking a CPP is not considered good or acceptable practice
     /// </remarks>
-    public const string DummyPartyName = "DummyCollaborationProtocolProfile";
+    private const string DummyPartyName = "DummyCollaborationProtocolProfile";
 
     private const string MessageFunctionExceptionProfileName = "MessageFunctionExceptionProfile";
 

--- a/test/Helsenorge.Messaging.Tests/BaseTest.cs
+++ b/test/Helsenorge.Messaging.Tests/BaseTest.cs
@@ -57,14 +57,14 @@ namespace Helsenorge.Messaging.Tests
         [TestInitialize]
         public virtual void Setup()
         {
-            _encryptionCertificate = TestCertificates.GetCertificate(TestCertificates.HelsenorgeLegacyEncryptionThumbprint); //TestCertificates.GenerateSelfSignedCertificate("ActorA", X509KeyUsageFlags.KeyEncipherment, DateTimeOffset.Now.AddDays(-1), DateTimeOffset.Now.AddMonths(1));
-            _signatureCertificate = TestCertificates.GetCertificate(TestCertificates.HelsenorgeSignatureThumbprint); //TestCertificates.GenerateSelfSignedCertificate("ActorA", X509KeyUsageFlags.NonRepudiation, DateTimeOffset.Now.AddDays(-1), DateTimeOffset.Now.AddMonths(1));
-
             SetupInternal(DefaultOtherHerId);
         }
 
         internal void SetupInternal(int otherHerId)
         {
+            _encryptionCertificate = TestCertificates.GetCertificate(TestCertificates.HelsenorgeLegacyEncryptionThumbprint); //TestCertificates.GenerateSelfSignedCertificate("ActorA", X509KeyUsageFlags.KeyEncipherment, DateTimeOffset.Now.AddDays(-1), DateTimeOffset.Now.AddMonths(1));
+            _signatureCertificate = TestCertificates.GetCertificate(TestCertificates.HelsenorgeSignatureThumbprint); //TestCertificates.GenerateSelfSignedCertificate("ActorA", X509KeyUsageFlags.NonRepudiation, DateTimeOffset.Now.AddDays(-1), DateTimeOffset.Now.AddMonths(1));
+
             var addressRegistrySettings = new AddressRegistrySettings()
             {
                 WcfConfiguration = new WcfConfiguration

--- a/test/Helsenorge.Messaging.Tests/ServiceBus/Senders/AsynchronousSendTestsWithoutCpp.cs
+++ b/test/Helsenorge.Messaging.Tests/ServiceBus/Senders/AsynchronousSendTestsWithoutCpp.cs
@@ -7,6 +7,7 @@
  */
 
 using System;
+using System.Collections.Generic;
 using Helsenorge.Messaging.Abstractions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -15,34 +16,79 @@ namespace Helsenorge.Messaging.Tests.ServiceBus.Senders
     [TestClass]
     public class AsynchronousSendTestsWithoutCpp : BaseTest
     {
-        private const int CommunicationPartyWithoutCppHerId = 94867;
+        private const int CommunicationPartyHerId = 93252;
 
         [TestInitialize]
         public override void Setup()
         {
-            SetupInternal(CommunicationPartyWithoutCppHerId);
+            SetupInternal(CommunicationPartyHerId);
         }
         
         private OutgoingMessage CreateMessageForCommunicationPartyWithoutCpp()
         {
             return new OutgoingMessage()
             {
-                ToHerId = CommunicationPartyWithoutCppHerId,
+                ToHerId = CommunicationPartyHerId,
                 Payload = GenericMessage,
-                MessageFunction = "DIALOG_INNBYGGER_EKONTAKT",
+                MessageFunction = "NO_CPA_MESSAGE",
                 MessageId = Guid.NewGuid().ToString("D"),
                 PersonalId = "12345"
             };
         }
 
-        [TestMethod, Ignore]
+        [TestMethod]
         public void Send_Asynchronous_CommunicationPartyWithoutCpp_OK()
         {
             var message = CreateMessageForCommunicationPartyWithoutCpp();
+            Settings.MessageFunctionsExcludedFromCpaResolve = new List<string> { "NO_CPA_MESSAGE" };
 
             RunAndHandleException(Client.SendAndContinueAsync(message));
 
             Assert.AreEqual(1, MockFactory.OtherParty.Asynchronous.Messages.Count);
+        }
+
+        [TestMethod]
+        public void Send_Asynchronous_CommunicationPartyWithoutCpp_Exception()
+        {
+            var message = CreateMessageForCommunicationPartyWithoutCpp();
+
+            Assert.ThrowsException<MessagingException>(() => RunAndHandleException(Client.SendAndContinueAsync(message)));
+
+            Assert.AreEqual(0, MockFactory.OtherParty.Asynchronous.Messages.Count);
+        }
+
+        private OutgoingMessage CreateApprecMessageForCommunicationPartyWithoutCpp()
+        {
+            return new OutgoingMessage()
+            {
+                ToHerId = CommunicationPartyHerId,
+                Payload = GenericMessage,
+                MessageFunction = "APPREC",
+                MessageId = Guid.NewGuid().ToString("D"),
+                PersonalId = "12345",
+                ReceiptForMessageFunction = "NO_CPA_MESSAGE",
+            };
+        }
+
+        [TestMethod]
+        public void Send_Asynchronous_Apprec_CommunicationPartyWithoutCpp_OK()
+        {
+            var message = CreateApprecMessageForCommunicationPartyWithoutCpp();
+            Settings.MessageFunctionsExcludedFromCpaResolve = new List<string> { "NO_CPA_MESSAGE" };
+
+            RunAndHandleException(Client.SendAndContinueAsync(message));
+
+            Assert.AreEqual(1, MockFactory.OtherParty.Asynchronous.Messages.Count);
+        }
+
+        [TestMethod]
+        public void Send_Asynchronous_Apprec_CommunicationPartyWithoutCpp_Exception()
+        {
+            var message = CreateApprecMessageForCommunicationPartyWithoutCpp();
+
+            Assert.ThrowsException<MessagingException>(() => RunAndHandleException(Client.SendAndContinueAsync(message)));
+
+            Assert.AreEqual(0, MockFactory.OtherParty.Asynchronous.Messages.Count);
         }
     }
 }

--- a/test/Helsenorge.Registries.Tests/CollaborationRegistryTests.cs
+++ b/test/Helsenorge.Registries.Tests/CollaborationRegistryTests.cs
@@ -147,13 +147,23 @@ namespace Helsenorge.Registries.Tests
         }
 
         [TestMethod]
-        public void Read_DummyCollaborationProfile_Found()
+        public void Read_MessageFunctionExceptionProfile_Found()
         {
             var profile = DummyCollaborationProtocolProfileFactory.CreateAsync(_addressRegistry, _logger, 93238, "NO_CPA_MESSAGE").Result;
             Assert.IsNotNull(profile);
             Assert.AreEqual("MessageFunctionExceptionProfile", profile.Name);
             Assert.AreEqual("NO_CPA_MESSAGE", profile.Roles.First().SendMessages.First().Name);
             Assert.AreEqual("NO_CPA_MESSAGE", profile.Roles.First().SendMessages.First().Action);
+        }
+
+        [TestMethod]
+        public void Read_DummyCollaborationProfile_Found()
+        {
+            var profile = DummyCollaborationProtocolProfileFactory.CreateAsync(_addressRegistry, _logger, 93238, null).Result;
+            Assert.IsNotNull(profile);
+            Assert.AreEqual("DummyCollaborationProtocolProfile", profile.Name);
+            Assert.AreEqual("APPREC", profile.Roles.First().SendMessages.First().Name);
+            Assert.AreEqual("APPREC", profile.Roles.First().SendMessages.First().Action);
         }
 
         [TestMethod, Ignore]


### PR DESCRIPTION
Sending APPREC for message functions without CPP/CPA resulted in an error even though the message function was listed in config variable MessageFunctionsExcludedFromCpaResolve. This PR fixes that issue.