### PR TITLE
Messaging: Revert to using string as data type for MessagingSettings.ConnectionString

### DIFF
--- a/Documentation/MigrateFrom4To5.md
+++ b/Documentation/MigrateFrom4To5.md
@@ -10,11 +10,14 @@ Alle `async` metoder har nå endelsen Async. F.eks `MessagingServer.Start` er n�
 
 - `MessagingSettings.MyHerId` &rarr; `MessagingSettings.MyHerIds`
   - Datatypen er endret fra `int` til `List<int>`
-- `MessagingSettings.ConnectionString` er endret til datatypen AmqpConnectionString. Denne implementasjonen forenkler byggingen av en connection string.
 - `CollaborationProtocolRegistrySettings.MyHerId` er fjernet
 - `MessagingSettings.ServiceBus` &rarr; `MessagingSettings.AmqpSettings`
 - Standardverdien tilhørende `MessagingSettings.AmqpSettings.MessageBrokerDialect` er endret fra `MessageBrokerDialect.ServiceBus`
   til `MessageBrokerDialect.RabbitMQ`
+
+### Nye features
+
+For å avhjelpe oppbygging av Connection String fra kode har klassen AmqpConnectionString blitt lagt til.
 
 ### Navneendring og endring av datatype for egenskapen MessagingSettings.MyHerId
 

--- a/Examples/PooledReceiver/Program.cs
+++ b/Examples/PooledReceiver/Program.cs
@@ -29,15 +29,16 @@ namespace PooledReceiver
         static async Task Main(string[] args)
         {
             var loggerFactory = new LoggerFactory();
+            var connectionString = new AmqpConnectionString
+            {
+                HostName = HostName,
+                Exchange = Exchange,
+                UserName = Username,
+                Password = Password,
+            };
             var settings = new AmqpSettings
             {
-                ConnectionString = new AmqpConnectionString
-                {
-                    HostName = HostName,
-                    Exchange = Exchange,
-                    UserName = Username,
-                    Password = Password,
-                }
+                ConnectionString = connectionString.ToString(),
             };
 
             await using var linkFactoryPool = new LinkFactoryPool(loggerFactory.CreateLogger<LinkFactoryPool>(), settings);

--- a/Examples/PooledSender/Program.cs
+++ b/Examples/PooledSender/Program.cs
@@ -30,18 +30,19 @@ namespace PooledSender
         static async Task Main(string[] args)
         {
             var loggerFactory = new LoggerFactory();
+            var connectionString = new AmqpConnectionString
+            {
+                HostName = HostName,
+                Exchange = Exchange,
+                UserName = Username,
+                Password = Password,
+            };
             var settings = new MessagingSettings
             {
                 ApplicationProperties = {{ "X-SystemIdentifier", "ExampleSystemIdentifier" }},
                 AmqpSettings =
                 {
-                    ConnectionString = new AmqpConnectionString
-                    {
-                        HostName = HostName,
-                        Exchange = Exchange,
-                        UserName = Username,
-                        Password = Password,
-                    },
+                    ConnectionString = connectionString.ToString(),
                 }
             };
 

--- a/Examples/SubscriptionExample/Program.cs
+++ b/Examples/SubscriptionExample/Program.cs
@@ -41,15 +41,16 @@ namespace SubscriptionExample
                 };
                 var busManager = new BusManager(busManagerSettings, loggerFactory.CreateLogger<BusManager>());
 
+                var connectionString = new AmqpConnectionString
+                {
+                    HostName = HostName,
+                    Exchange = Exchange,
+                    UserName = Username,
+                    Password = Password,
+                };
                 var serviceBusSettings = new AmqpSettings
                 {
-                    ConnectionString = new AmqpConnectionString
-                    {
-                        HostName = HostName,
-                        Exchange = Exchange,
-                        UserName = Username,
-                        Password = Password,
-                    },
+                    ConnectionString = connectionString.ToString(),
                 };
                 await using var linkFactoryPool = new LinkFactoryPool(loggerFactory.CreateLogger("LinkFactoryPool"), serviceBusSettings);
 

--- a/src/Helsenorge.Messaging/MessagingSettings.cs
+++ b/src/Helsenorge.Messaging/MessagingSettings.cs
@@ -124,7 +124,7 @@ namespace Helsenorge.Messaging
         /// <summary>
         /// Gets or sets the connection string
         /// </summary>
-        public AmqpConnectionString ConnectionString { get; set; }
+        public string ConnectionString { get; set; }
         /// <summary>
         /// Provides access to settings related to asynchronous queues
         /// </summary>

--- a/test/Helsenorge.Messaging.Tests/BaseTest.cs
+++ b/test/Helsenorge.Messaging.Tests/BaseTest.cs
@@ -145,10 +145,7 @@ namespace Helsenorge.Messaging.Tests
                 }
             };
 
-            Settings.AmqpSettings.ConnectionString = new AmqpConnectionString
-            {
-                HostName = "blabla",
-            };
+            Settings.AmqpSettings.ConnectionString = "blabla";
             Settings.AmqpSettings.Synchronous.ReplyQueueMapping.Add(Environment.MachineName.ToLower(), "RepliesGoHere");
             // make things easier by only having one processing task per queue
             Settings.AmqpSettings.Asynchronous.ProcessingTasks = 1;


### PR DESCRIPTION
This reverts us back to using string as data type for the configuration
setting MessagingSettings.ConnectionString.