### PR TITLE
Messaging: Add Protect overload to IMessageProtection

### DIFF
--- a/src/Helsenorge.Messaging/Abstractions/IMessageProtection.cs
+++ b/src/Helsenorge.Messaging/Abstractions/IMessageProtection.cs
@@ -47,6 +47,15 @@ namespace Helsenorge.Messaging.Abstractions
         Stream Protect(Stream data, X509Certificate2 encryptionCertificate);
 
         /// <summary>
+        /// Signs and then encrypts the contents of <paramref name="data"/>.
+        /// </summary>
+        /// <param name="data">A <see cref="Stream"/> containing the data that will be signed and then encrypted.</param>
+        /// <param name="encryptionCertificate">The public key <see cref="X509Certificate2"/> which will be used to encrypt the data.</param>
+        /// <param name="signingCertificate">The private key <see cref="X509Certificate2"/>which will be used to sign the data.</param>
+        /// <returns>A <see cref="Stream"/> containing the signed and encrypted data.</returns>
+        Stream Protect(Stream data, X509Certificate2 encryptionCertificate, X509Certificate2 signingCertificate);
+
+        /// <summary>
         /// Decrypts and then verifies the signature of the content in <paramref name="data"/>.
         /// </summary>
         /// <param name="data">A <see cref="Stream"/> containing the data which be decrypted and then the signature will be verified.</param>

--- a/src/Helsenorge.Messaging/Abstractions/MessageProtection.cs
+++ b/src/Helsenorge.Messaging/Abstractions/MessageProtection.cs
@@ -59,6 +59,12 @@ namespace Helsenorge.Messaging.Abstractions
             throw new NotImplementedException();
         }
 
+        /// <inheritdoc/>
+        public virtual Stream Protect(Stream data, X509Certificate2 encryptionCertificate, X509Certificate2 signingCertificate)
+        {
+            throw new NotImplementedException();
+        }
+
         /// <summary>
         /// Decrypts and then verifies the signature of the content in <paramref name="data"/>.
         /// </summary>

--- a/src/Helsenorge.Messaging/Security/NoMessageProtection.cs
+++ b/src/Helsenorge.Messaging/Security/NoMessageProtection.cs
@@ -46,6 +46,12 @@ namespace Helsenorge.Messaging.Security
             return data;
         }
 
+        /// <inheritdoc/>
+        public Stream Protect(Stream data, X509Certificate2 encryptionCertificate, X509Certificate2 signingCertificate)
+        {
+            return data;
+        }
+
         /// <summary>
         /// Decrypts and then verifies the signature of the content in <paramref name="data"/>.
         /// </summary>

--- a/src/Helsenorge.Messaging/Security/SignThenEncryptMessageProtection.cs
+++ b/src/Helsenorge.Messaging/Security/SignThenEncryptMessageProtection.cs
@@ -61,20 +61,27 @@ namespace Helsenorge.Messaging.Security
         /// <returns>A <see cref="Stream"/> containing the signed and encrypted data.</returns>
         public override Stream Protect(Stream data, X509Certificate2 encryptionCertificate)
         {
+            return Protect(data, encryptionCertificate, SigningCertificate);
+        }
+
+        /// <inheritdoc/>
+        public override Stream Protect(Stream data, X509Certificate2 encryptionCertificate, X509Certificate2 signingCertificate)
+        {
             if (data == null) throw new ArgumentNullException(nameof(data));
             if (encryptionCertificate == null) throw new ArgumentNullException(nameof(encryptionCertificate));
+            if (signingCertificate == null) throw new ArgumentNullException(nameof(signingCertificate));
 
             byte[] dataAsBytes = new byte[data.Length];
             data.Read(dataAsBytes, 0, (int)data.Length);
 
-            return new MemoryStream(Protect(dataAsBytes, encryptionCertificate));
+            return new MemoryStream(Protect(dataAsBytes, encryptionCertificate, signingCertificate));
         }
 
-        private byte[] Protect(byte[] data, X509Certificate2 encryptionCertificate)
+        private byte[] Protect(byte[] data, X509Certificate2 encryptionCertificate, X509Certificate2 signingCertificate)
         {
             // first we sign the message
             var signedCms = new SignedCms(new ContentInfo(data));
-            var signer = new CmsSigner(SigningCertificate);
+            var signer = new CmsSigner(signingCertificate);
             if (_includeOption.HasValue)
             {
                 signer.IncludeOption = _includeOption.Value;

--- a/test/Helsenorge.Messaging.Tests/Amqp/Receivers/AsynchronousReceiveTests.cs
+++ b/test/Helsenorge.Messaging.Tests/Amqp/Receivers/AsynchronousReceiveTests.cs
@@ -679,6 +679,13 @@ namespace Helsenorge.Messaging.Tests.Amqp.Receivers
                 return data;
             }
 
+            public Stream Protect(Stream data, X509Certificate2 encryptionCertificate, X509Certificate2 signingCertificate)
+            {
+                if (data == null) throw new ArgumentNullException(nameof(data));
+
+                return data;
+            }
+
             public Stream Unprotect(Stream data, X509Certificate2 signingCertificate)
             {
                 throw new SecurityException("Invalid certificate");


### PR DESCRIPTION
This adds the overload `Protect(Stream, X509Certificate2, X509Certificate2)` to `IMessageProtection`.