### PR TITLE
Messaging: Check if Map already contains 'enqueuedTimeUtc'

### DIFF
--- a/src/Helsenorge.Messaging/Amqp/AmqpSender.cs
+++ b/src/Helsenorge.Messaging/Amqp/AmqpSender.cs
@@ -82,7 +82,7 @@ namespace Helsenorge.Messaging.Amqp
             {
                 await EnsureOpenAsync().ConfigureAwait(false);
                 originalMessage.ApplicationProperties.AddApplicationProperties(_applicationProperties);
-                originalMessage.ApplicationProperties.Map.Add(AmqpCore.EnqueuedTimeUtc, DateTime.UtcNow);
+                originalMessage.ApplicationProperties.SetEnqueuedTimeUtc(DateTime.UtcNow);
                 await _link.SendAsync(originalMessage).ConfigureAwait(false);
             }).PerformAsync().ConfigureAwait(false);
         }

--- a/src/Helsenorge.Messaging/ApplicationPropertiesExtensions.cs
+++ b/src/Helsenorge.Messaging/ApplicationPropertiesExtensions.cs
@@ -6,8 +6,10 @@
  * available at https://raw.githubusercontent.com/helsenorge/Helsenorge.Messaging/master/LICENSE
  */
 
+using System;
 using System.Collections.Generic;
 using Amqp.Framing;
+using Helsenorge.Messaging.Amqp;
 
 namespace Helsenorge.Messaging
 {
@@ -17,6 +19,14 @@ namespace Helsenorge.Messaging
         {
             foreach (var property in properties)
                 applicationProperties[property.Key] = property.Value;
+        }
+
+        public static void SetEnqueuedTimeUtc(this ApplicationProperties applicationProperties, DateTime utcTime)
+        {
+            if (applicationProperties.Map.ContainsKey(AmqpCore.EnqueuedTimeUtc))
+                applicationProperties.Map[AmqpCore.EnqueuedTimeUtc] = utcTime;
+            else
+                applicationProperties.Map.Add(AmqpCore.EnqueuedTimeUtc, utcTime);
         }
     }
 }


### PR DESCRIPTION
This patch checks if the map already contains a key with name 'enqueuedTimeUtc'. If it exists update the value, if not add it.

https://norskhelsenett.slack.com/archives/C03HKUXDTT6/p1679403558780279