### PR TITLE
Messaging: Always use MessageFunction not ReceiptForMessageFunction

### DIFF
--- a/src/Helsenorge.Messaging/Amqp/LinkFactory.cs
+++ b/src/Helsenorge.Messaging/Amqp/LinkFactory.cs
@@ -70,9 +70,7 @@ namespace Helsenorge.Messaging.Amqp
             return new AmqpMessage(innerMessage)
             {
                 MessageId = message.MessageId,
-                MessageFunction = string.IsNullOrWhiteSpace(message.ReceiptForMessageFunction)
-                    ? message.MessageFunction
-                    : message.ReceiptForMessageFunction,
+                MessageFunction = message.MessageFunction,
                 ToHerId = message.ToHerId,
                 FromHerId = fromHerId,
             };

--- a/src/Helsenorge.Messaging/Amqp/LinkFactoryPool.cs
+++ b/src/Helsenorge.Messaging/Amqp/LinkFactoryPool.cs
@@ -87,9 +87,7 @@ namespace Helsenorge.Messaging.Amqp
             return new AmqpMessage(innerMessage)
             {
                 MessageId = message.MessageId,
-                MessageFunction = string.IsNullOrWhiteSpace(message.ReceiptForMessageFunction)
-                    ? message.MessageFunction
-                    : message.ReceiptForMessageFunction,
+                MessageFunction = message.MessageFunction,
                 ToHerId = message.ToHerId,
                 FromHerId = fromHerId,
             };


### PR DESCRIPTION
This transfer MessageFunction from OutgoingMessage to AmqpMessage the same way we do in MessagingClient, always transferring MessageFunction, not ReceiptForMessageFunction.