### PR TITLE
Messaging: Always use MessageFunction not ReceiptForMessageFunction [v4]

### DIFF
--- a/src/Helsenorge.Messaging/ServiceBus/LinkFactory.cs
+++ b/src/Helsenorge.Messaging/ServiceBus/LinkFactory.cs
@@ -70,9 +70,7 @@ namespace Helsenorge.Messaging.ServiceBus
             return new ServiceBusMessage(innerMessage)
             {
                 MessageId = message.MessageId,
-                MessageFunction = string.IsNullOrWhiteSpace(message.ReceiptForMessageFunction)
-                    ? message.MessageFunction
-                    : message.ReceiptForMessageFunction,
+                MessageFunction = message.MessageFunction,
                 ToHerId = message.ToHerId,
                 FromHerId = fromHerId,
                 ScheduledEnqueueTimeUtc = message.ScheduledSendTimeUtc,

--- a/src/Helsenorge.Messaging/ServiceBus/LinkFactoryPool.cs
+++ b/src/Helsenorge.Messaging/ServiceBus/LinkFactoryPool.cs
@@ -87,9 +87,7 @@ namespace Helsenorge.Messaging.ServiceBus
             return new ServiceBusMessage(innerMessage)
             {
                 MessageId = message.MessageId,
-                MessageFunction = string.IsNullOrWhiteSpace(message.ReceiptForMessageFunction)
-                    ? message.MessageFunction
-                    : message.ReceiptForMessageFunction,
+                MessageFunction = message.MessageFunction,
                 ToHerId = message.ToHerId,
                 FromHerId = fromHerId,
                 ScheduledEnqueueTimeUtc = message.ScheduledSendTimeUtc,


### PR DESCRIPTION
This transfer MessageFunction from OutgoingMessage to ServiceBusMessage the same way we do in MessagingClient, always transferring MessageFunction, not ReceiptForMessageFunction.