### PR TITLE
Registries: Manually {de,}serialize CertificateDetails.Certificate

### DIFF
--- a/src/Helsenorge.Registries/Abstractions/CertificateDetails.cs
+++ b/src/Helsenorge.Registries/Abstractions/CertificateDetails.cs
@@ -21,7 +21,7 @@ namespace Helsenorge.Registries.Abstractions
         public int HerId { get; set; }
 
         /// <summary>
-        /// The certificate of the communcation party represented as a byte array.
+        /// The certificate of the communication party represented as a byte array.
         /// </summary>
         public X509Certificate2 Certificate { get; set; }
 

--- a/src/Helsenorge.Registries/Abstractions/CertificateDetails.cs
+++ b/src/Helsenorge.Registries/Abstractions/CertificateDetails.cs
@@ -6,6 +6,8 @@
  * available at https://raw.githubusercontent.com/helsenorge/Helsenorge.Messaging/master/LICENSE
  */
 
+using System;
+using System.Runtime.Serialization;
 using System.Security.Cryptography.X509Certificates;
 
 namespace Helsenorge.Registries.Abstractions
@@ -13,8 +15,12 @@ namespace Helsenorge.Registries.Abstractions
     /// <summary>
     /// Represents information about the Certificate
     /// </summary>
+    [Serializable]
     public class CertificateDetails
     {
+        // These are used during serialization and deserialization since X509Certificate2 and X509Certificate are no longer serializable in .net core.
+        private string _certificateBase64String;
+
         /// <summary>
         /// The HER-ID of the communication party. This is identifies this party in the Address Registry
         /// </summary>
@@ -23,11 +29,34 @@ namespace Helsenorge.Registries.Abstractions
         /// <summary>
         /// The certificate of the communication party represented as a byte array.
         /// </summary>
+        [field: NonSerialized]
         public X509Certificate2 Certificate { get; set; }
 
         /// <summary>
         /// The complete url for the certificate.
         /// </summary>
         public string LdapUrl { get; set; }
+
+        /// <summary>
+        /// Called on serializing the object, exports the certificate to a base64-encoded string.
+        /// </summary>
+        [OnSerializing]
+        internal void OnSerializing(StreamingContext context)
+        {
+            _certificateBase64String = Certificate == null
+                ? null
+                : Convert.ToBase64String(Certificate.Export(X509ContentType.Cert));
+        }
+
+        /// <summary>
+        /// Called when object is deserialized, imports the certificates from the previously serialized base64-encoded string.
+        /// </summary>
+        [OnDeserialized]
+        internal void OnDeserialized(StreamingContext context)
+        {
+            Certificate = string.IsNullOrWhiteSpace(_certificateBase64String)
+                ? null
+                : new X509Certificate2(Convert.FromBase64String(_certificateBase64String));
+        }
     }
 }

--- a/test/Helsenorge.Registries.Tests/AddressRegistryTests.cs
+++ b/test/Helsenorge.Registries.Tests/AddressRegistryTests.cs
@@ -271,5 +271,27 @@ namespace Helsenorge.Registries.Tests
             Assert.AreEqual(serviceDetails.LdapUrl, deserialized.LdapUrl);
             Assert.AreEqual(cert.Thumbprint, deserializedCert.Thumbprint);
         }
+
+        [TestMethod]
+        public void Serialize_Abstractions_CertificateDetails()
+        {
+            var keys = ECDsa.Create();
+            var request = new CertificateRequest("CN=foo", keys, HashAlgorithmName.SHA256);
+            var cert = request.CreateSelfSigned(DateTimeOffset.Now, DateTimeOffset.Now.AddYears(1));
+
+            var serviceDetails = new Abstractions.CertificateDetails
+            {
+                Certificate = cert,
+                HerId = 1234,
+                LdapUrl = "ldap://CN=foo",
+            };
+
+            var serialized = XmlCacheFormatter.Serialize(serviceDetails);
+            var deserialized = XmlCacheFormatter.DeserializeAsync<Abstractions.CertificateDetails>(serialized).Result;
+            var deserializedCert = deserialized.Certificate;
+            Assert.AreEqual(cert.Thumbprint, deserializedCert.Thumbprint);
+            Assert.AreEqual(serviceDetails.HerId, deserialized.HerId);
+            Assert.AreEqual(cert.Thumbprint, deserializedCert.Thumbprint);
+        }
     }
 }


### PR DESCRIPTION
This marks the class `CertificateDetails` as `Serializable` and manually serializes/deserializes the certificate to/from a base64 string.