### PR TITLE
Registries: Add XML comment to publicy visible type CacheExtensions

### DIFF
--- a/src/Helsenorge.Registries/Utilities/CacheExtensions.cs
+++ b/src/Helsenorge.Registries/Utilities/CacheExtensions.cs
@@ -7,14 +7,15 @@
  */
 
 using System;
-using System.IO;
-using System.Runtime.Serialization.Formatters.Binary;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Caching.Distributed;
 using Microsoft.Extensions.Logging;
 
 namespace Helsenorge.Registries.Utilities
 {
+    /// <summary>
+    /// Extension methods for IDistributedCache
+    /// </summary>
     public static class CacheExtensions
     {
         /// <summary>


### PR DESCRIPTION
This removes warning: "Missing XML comment for publicly visible type or member 'CacheExtensions'".