### PR TITLE
Log out what encryption algorithm is being used when unprotecting

### DIFF
--- a/Examples/ReceiveDecryptAndValidate/Program.cs
+++ b/Examples/ReceiveDecryptAndValidate/Program.cs
@@ -65,7 +65,7 @@ namespace ReceiveDecryptAndValidate
                         if (message.ContentType == ContentType.SignedAndEnveloped)
                         {
                             var publicSignatureCertificate = await addressRegistry.GetCertificateDetailsForValidatingSignatureAsync(123);
-                            streamReader = new StreamReader(messageProtection.Unprotect(stream, publicSignatureCertificate.Certificate));
+                            streamReader = new StreamReader(messageProtection.Unprotect(stream, publicSignatureCertificate.Certificate, loggerFactory.CreateLogger<SignThenEncryptMessageProtection>()));
                         }
                         else
                         {

--- a/Examples/ReceiveDecryptAndValidate/Program.cs
+++ b/Examples/ReceiveDecryptAndValidate/Program.cs
@@ -44,7 +44,7 @@ namespace ReceiveDecryptAndValidate
                 var certificateStore = new MockCertificateStore();
                 var signatureCertificate = certificateStore.GetCertificate(TestCertificates.CounterpartySignatureThumbprint);
                 var encryptionCertificate = certificateStore.GetCertificate(TestCertificates.CounterpartyEncryptionThumbprint);
-                var messageProtection = new SignThenEncryptMessageProtection(signatureCertificate, encryptionCertificate);
+                var messageProtection = new SignThenEncryptMessageProtection(signatureCertificate, encryptionCertificate, loggerFactory.CreateLogger<SignThenEncryptMessageProtection>());
 
                 var addressRegistry = new MockAddressRegistry();
 
@@ -65,7 +65,7 @@ namespace ReceiveDecryptAndValidate
                         if (message.ContentType == ContentType.SignedAndEnveloped)
                         {
                             var publicSignatureCertificate = await addressRegistry.GetCertificateDetailsForValidatingSignatureAsync(123);
-                            streamReader = new StreamReader(messageProtection.Unprotect(stream, publicSignatureCertificate.Certificate, loggerFactory.CreateLogger<SignThenEncryptMessageProtection>()));
+                            streamReader = new StreamReader(messageProtection.Unprotect(stream, publicSignatureCertificate.Certificate));
                         }
                         else
                         {

--- a/Examples/SignEncryptAndSend/Program.cs
+++ b/Examples/SignEncryptAndSend/Program.cs
@@ -46,7 +46,7 @@ namespace SignEncryptAndSend
                 var certificateStore = new MockCertificateStore();
                 var signatureCertificate = certificateStore.GetCertificate(TestCertificates.HelsenorgeSignatureThumbprint);
                 var encryptionCertificate = certificateStore.GetCertificate(TestCertificates.HelsenorgeEncryptionThumbprint);
-                var messageProtection = new SignThenEncryptMessageProtection(signatureCertificate, encryptionCertificate);
+                var messageProtection = new SignThenEncryptMessageProtection(signatureCertificate, encryptionCertificate, loggerFactory.CreateLogger<SignThenEncryptMessageProtection>());
 
                 var addressRegistry = new MockAddressRegistry();
 

--- a/src/Helsenorge.Messaging/Abstractions/IMessageProtection.cs
+++ b/src/Helsenorge.Messaging/Abstractions/IMessageProtection.cs
@@ -6,6 +6,7 @@
  * available at https://raw.githubusercontent.com/helsenorge/Helsenorge.Messaging/master/LICENSE
  */
 
+using Microsoft.Extensions.Logging;
 using System;
 using System.IO;
 using System.Security.Cryptography.X509Certificates;
@@ -60,7 +61,8 @@ namespace Helsenorge.Messaging.Abstractions
         /// </summary>
         /// <param name="data">A <see cref="Stream"/> containing the data which be decrypted and then the signature will be verified.</param>
         /// <param name="signingCertificate">The public key <see cref="X509Certificate2"/> which will be used to validate the signature of the message data.</param>
+        /// <param name="logger"></param>
         /// <returns>A <see cref="Stream"/> containing the data in decrypted form.</returns>
-        Stream Unprotect(Stream data, X509Certificate2 signingCertificate);
+        Stream Unprotect(Stream data, X509Certificate2 signingCertificate, ILogger logger);
     }
 }

--- a/src/Helsenorge.Messaging/Abstractions/IMessageProtection.cs
+++ b/src/Helsenorge.Messaging/Abstractions/IMessageProtection.cs
@@ -61,8 +61,7 @@ namespace Helsenorge.Messaging.Abstractions
         /// </summary>
         /// <param name="data">A <see cref="Stream"/> containing the data which be decrypted and then the signature will be verified.</param>
         /// <param name="signingCertificate">The public key <see cref="X509Certificate2"/> which will be used to validate the signature of the message data.</param>
-        /// <param name="logger"></param>
         /// <returns>A <see cref="Stream"/> containing the data in decrypted form.</returns>
-        Stream Unprotect(Stream data, X509Certificate2 signingCertificate, ILogger logger);
+        Stream Unprotect(Stream data, X509Certificate2 signingCertificate);
     }
 }

--- a/src/Helsenorge.Messaging/Abstractions/MessageProtection.cs
+++ b/src/Helsenorge.Messaging/Abstractions/MessageProtection.cs
@@ -6,6 +6,7 @@
  * available at https://raw.githubusercontent.com/helsenorge/Helsenorge.Messaging/master/LICENSE
  */
 
+using Microsoft.Extensions.Logging;
 using System;
 using System.IO;
 using System.Security.Cryptography.X509Certificates;
@@ -70,8 +71,9 @@ namespace Helsenorge.Messaging.Abstractions
         /// </summary>
         /// <param name="data">A <see cref="Stream"/> containing the data which be decrypted and then the signature will be verified.</param>
         /// <param name="signingCertificate">The public key <see cref="X509Certificate2"/> which will be used to validate the signature of the message data.</param>
+        /// <param name="logger"></param>
         /// <returns>A <see cref="Stream"/> containing the data in decrypted form.</returns>
-        public virtual Stream Unprotect(Stream data, X509Certificate2 signingCertificate)
+        public virtual Stream Unprotect(Stream data, X509Certificate2 signingCertificate, ILogger logger)
         {
             throw new NotImplementedException();
         }

--- a/src/Helsenorge.Messaging/Abstractions/MessageProtection.cs
+++ b/src/Helsenorge.Messaging/Abstractions/MessageProtection.cs
@@ -71,9 +71,8 @@ namespace Helsenorge.Messaging.Abstractions
         /// </summary>
         /// <param name="data">A <see cref="Stream"/> containing the data which be decrypted and then the signature will be verified.</param>
         /// <param name="signingCertificate">The public key <see cref="X509Certificate2"/> which will be used to validate the signature of the message data.</param>
-        /// <param name="logger"></param>
         /// <returns>A <see cref="Stream"/> containing the data in decrypted form.</returns>
-        public virtual Stream Unprotect(Stream data, X509Certificate2 signingCertificate, ILogger logger)
+        public virtual Stream Unprotect(Stream data, X509Certificate2 signingCertificate)
         {
             throw new NotImplementedException();
         }

--- a/src/Helsenorge.Messaging/Amqp/Receivers/MessageListener.cs
+++ b/src/Helsenorge.Messaging/Amqp/Receivers/MessageListener.cs
@@ -379,7 +379,7 @@ namespace Helsenorge.Messaging.Amqp.Receivers
             {
                 contentWasSigned = false;
                 // no certificates to validate
-                payload = new NoMessageProtection().Unprotect(bodyStream, null)?.ToXDocument();
+                payload = new NoMessageProtection().Unprotect(bodyStream, null, Logger)?.ToXDocument();
 
                 // Log a warning if the message is in plain text.
                 if (AmqpCore.Settings.LogMessagesNotSignedAndEnvelopedAsWarning && isPlainText)

--- a/src/Helsenorge.Messaging/Amqp/Receivers/MessageListener.cs
+++ b/src/Helsenorge.Messaging/Amqp/Receivers/MessageListener.cs
@@ -444,7 +444,7 @@ namespace Helsenorge.Messaging.Amqp.Receivers
                 Logger.LogBeforeDecryptingPayload(originalMessage.MessageFunction, signature?.Thumbprint, AmqpCore.MessageProtection.EncryptionCertificate.Thumbprint, originalMessage.FromHerId, originalMessage.ToHerId, originalMessage.MessageId);
                 stopwatch.Restart();
                 // decrypt the message and validate the signatureS
-                payload = AmqpCore.MessageProtection.Unprotect(bodyStream, signature)?.ToXDocument();
+                payload = AmqpCore.MessageProtection.Unprotect(bodyStream, signature, Logger)?.ToXDocument();
                 Logger.LogAfterDecryptingPayload(originalMessage.MessageFunction, originalMessage.FromHerId, originalMessage.ToHerId, originalMessage.MessageId, stopwatch.ElapsedMilliseconds.ToString());
                 stopwatch.Stop();
             }

--- a/src/Helsenorge.Messaging/Amqp/Receivers/MessageListener.cs
+++ b/src/Helsenorge.Messaging/Amqp/Receivers/MessageListener.cs
@@ -379,7 +379,7 @@ namespace Helsenorge.Messaging.Amqp.Receivers
             {
                 contentWasSigned = false;
                 // no certificates to validate
-                payload = new NoMessageProtection().Unprotect(bodyStream, null, Logger)?.ToXDocument();
+                payload = new NoMessageProtection().Unprotect(bodyStream, null)?.ToXDocument();
 
                 // Log a warning if the message is in plain text.
                 if (AmqpCore.Settings.LogMessagesNotSignedAndEnvelopedAsWarning && isPlainText)
@@ -444,7 +444,7 @@ namespace Helsenorge.Messaging.Amqp.Receivers
                 Logger.LogBeforeDecryptingPayload(originalMessage.MessageFunction, signature?.Thumbprint, AmqpCore.MessageProtection.EncryptionCertificate.Thumbprint, originalMessage.FromHerId, originalMessage.ToHerId, originalMessage.MessageId);
                 stopwatch.Restart();
                 // decrypt the message and validate the signatureS
-                payload = AmqpCore.MessageProtection.Unprotect(bodyStream, signature, Logger)?.ToXDocument();
+                payload = AmqpCore.MessageProtection.Unprotect(bodyStream, signature)?.ToXDocument();
                 Logger.LogAfterDecryptingPayload(originalMessage.MessageFunction, originalMessage.FromHerId, originalMessage.ToHerId, originalMessage.MessageId, stopwatch.ElapsedMilliseconds.ToString());
                 stopwatch.Stop();
             }

--- a/src/Helsenorge.Messaging/MessagingClient.cs
+++ b/src/Helsenorge.Messaging/MessagingClient.cs
@@ -40,7 +40,7 @@ namespace Helsenorge.Messaging
             MessagingSettings settings,
             ILoggerFactory loggerFactory,
             ICollaborationProtocolRegistry collaborationProtocolRegistry,
-            IAddressRegistry addressRegistry) : base(settings, collaborationProtocolRegistry, addressRegistry)
+            IAddressRegistry addressRegistry) : base(settings, collaborationProtocolRegistry, addressRegistry, loggerFactory)
         {
             _loggerFactory = loggerFactory ?? throw new ArgumentNullException(nameof(loggerFactory));
             _logger = _loggerFactory.CreateLogger(nameof(MessagingClient));
@@ -61,7 +61,7 @@ namespace Helsenorge.Messaging
             ILoggerFactory loggerFactory,
             ICollaborationProtocolRegistry collaborationProtocolRegistry,
             IAddressRegistry addressRegistry,
-            ICertificateStore certificateStore) : base(settings, collaborationProtocolRegistry, addressRegistry, certificateStore)
+            ICertificateStore certificateStore) : base(settings, collaborationProtocolRegistry, addressRegistry, certificateStore, loggerFactory)
         {
             _loggerFactory = loggerFactory ?? throw new ArgumentNullException(nameof(loggerFactory));
             _logger = _loggerFactory.CreateLogger(nameof(MessagingClient));
@@ -86,7 +86,7 @@ namespace Helsenorge.Messaging
             IAddressRegistry addressRegistry,
             ICertificateStore certificateStore,
             ICertificateValidator certificateValidator,
-            IMessageProtection messageProtection) : base(settings, collaborationProtocolRegistry, addressRegistry, certificateStore, certificateValidator, messageProtection)
+            IMessageProtection messageProtection) : base(settings, collaborationProtocolRegistry, addressRegistry, certificateStore, certificateValidator, messageProtection, loggerFactory)
         {
             _loggerFactory = loggerFactory ?? throw new ArgumentNullException(nameof(loggerFactory));
             _logger = _loggerFactory.CreateLogger(nameof(MessagingClient));

--- a/src/Helsenorge.Messaging/MessagingCore.cs
+++ b/src/Helsenorge.Messaging/MessagingCore.cs
@@ -15,6 +15,7 @@ using Helsenorge.Messaging.Security;
 using Helsenorge.Messaging.Amqp;
 using Helsenorge.Registries;
 using Helsenorge.Registries.Abstractions;
+using Microsoft.Extensions.Logging;
 
 namespace Helsenorge.Messaging
 {
@@ -23,23 +24,30 @@ namespace Helsenorge.Messaging
     /// </summary>
     public abstract class MessagingCore
     {
+        private readonly ILoggerFactory _loggerFactory;
+        private readonly ILogger _logger;
+
         /// <summary>
         /// Constructor
         /// </summary>
         /// <param name="settings">Set of options to use</param>
         /// <param name="collaborationProtocolRegistry">Reference to the collaboration protocol registry</param>
         /// <param name="addressRegistry">Reference to the address registry</param>
+        /// <param name="loggerFactory"></param>
         /// <exception cref="ArgumentNullException"></exception>
         /// <exception cref="ArgumentOutOfRangeException"></exception>
         protected MessagingCore(
             MessagingSettings settings,
             ICollaborationProtocolRegistry collaborationProtocolRegistry,
-            IAddressRegistry addressRegistry)
+            IAddressRegistry addressRegistry,
+            ILoggerFactory loggerFactory)
             : this(settings)
         {
             Settings = settings ?? throw new ArgumentNullException(nameof(settings));
             CollaborationProtocolRegistry = collaborationProtocolRegistry ?? throw new ArgumentNullException(nameof(collaborationProtocolRegistry));
             AddressRegistry = addressRegistry ?? throw new ArgumentNullException(nameof(addressRegistry));
+            _loggerFactory = loggerFactory;
+            _logger = _loggerFactory.CreateLogger<MessagingCore>();
             AmqpCore = new AmqpCore(this);
 
             Settings.Validate();
@@ -59,13 +67,15 @@ namespace Helsenorge.Messaging
         /// Reference to a custom implementation of <see cref="ICertificateStore"/>, if not set the library will default to Windows Certificate Store.
         /// Setting this argument to null will throw an <see cref="ArgumentNullException"/>.
         /// </param>
+        /// <param name="loggerFactory"></param>
         /// <exception cref="ArgumentNullException"></exception>
         /// <exception cref="ArgumentOutOfRangeException"></exception>
         protected MessagingCore(
             MessagingSettings settings,
             ICollaborationProtocolRegistry collaborationProtocolRegistry,
             IAddressRegistry addressRegistry,
-            ICertificateStore certificateStore)
+            ICertificateStore certificateStore,
+            ILoggerFactory loggerFactory)
             : this(settings)
         {
             Settings = settings ?? throw new ArgumentNullException(nameof(settings));
@@ -76,6 +86,8 @@ namespace Helsenorge.Messaging
             Settings.Validate();
 
             CertificateStore = certificateStore ?? throw new ArgumentNullException(nameof(certificateStore));
+            _loggerFactory = loggerFactory;
+            _logger = _loggerFactory.CreateLogger<MessagingCore>();
             CertificateValidator = GetDefaultCertificateValidator();
             MessageProtection = GetDefaultMessageProtection();
         }
@@ -99,6 +111,7 @@ namespace Helsenorge.Messaging
         /// Reference to custom implementation of <see cref="IMessageProtection"/>, if not set the library will default to standard behavior which relies on
         /// certificates retrieved from <see cref="ICertificateStore"/>. Setting this parameter to null will throw an <see cref="ArgumentNullException"/>.
         /// </param>
+        /// <param name="loggerFactory"></param>
         /// <exception cref="ArgumentNullException"></exception>
         /// <exception cref="ArgumentOutOfRangeException"></exception>
         protected MessagingCore(
@@ -107,7 +120,8 @@ namespace Helsenorge.Messaging
             IAddressRegistry addressRegistry,
             ICertificateStore certificateStore,
             ICertificateValidator certificateValidator,
-            IMessageProtection messageProtection)
+            IMessageProtection messageProtection,
+            ILoggerFactory loggerFactory)
             : this(settings)
         {
             Settings = settings ?? throw new ArgumentNullException(nameof(settings));
@@ -120,6 +134,8 @@ namespace Helsenorge.Messaging
             CertificateStore = certificateStore;
             CertificateValidator = certificateValidator;
             MessageProtection = messageProtection ?? throw new ArgumentNullException(nameof(messageProtection));
+            _loggerFactory = loggerFactory;
+            _logger = _loggerFactory.CreateLogger<MessagingCore>();
         }
 
         private MessagingCore(MessagingSettings settings)
@@ -180,7 +196,7 @@ namespace Helsenorge.Messaging
             var legacyEncryptionCertificate = Settings.LegacyDecryptionCertificate == null ? null : CertificateStore.GetCertificate(Settings.LegacyDecryptionCertificate.Thumbprint);
 
 #pragma warning disable CS0618
-            return new SignThenEncryptMessageProtection(signingCertificate, encryptionCertificate, legacyEncryptionCertificate, messagingEncryptionType: Settings.MessagingEncryptionType);
+            return new SignThenEncryptMessageProtection(signingCertificate, encryptionCertificate, _logger, legacyEncryptionCertificate, messagingEncryptionType: Settings.MessagingEncryptionType);
 #pragma warning restore CS0618
         }
 

--- a/src/Helsenorge.Messaging/MessagingServer.cs
+++ b/src/Helsenorge.Messaging/MessagingServer.cs
@@ -89,7 +89,7 @@ namespace Helsenorge.Messaging
             MessagingSettings settings,
             ILoggerFactory loggerFactory,
             ICollaborationProtocolRegistry collaborationProtocolRegistry,
-            IAddressRegistry addressRegistry) : base(settings, collaborationProtocolRegistry, addressRegistry)
+            IAddressRegistry addressRegistry) : base(settings, collaborationProtocolRegistry, addressRegistry, loggerFactory)
         {
             _loggerFactory = loggerFactory ?? throw new ArgumentNullException(nameof(loggerFactory));
             _logger = _loggerFactory.CreateLogger(nameof(MessagingServer));
@@ -108,7 +108,7 @@ namespace Helsenorge.Messaging
             ILoggerFactory loggerFactory,
             ICollaborationProtocolRegistry collaborationProtocolRegistry,
             IAddressRegistry addressRegistry,
-            ICertificateStore certificateStore) : base(settings, collaborationProtocolRegistry, addressRegistry, certificateStore)
+            ICertificateStore certificateStore) : base(settings, collaborationProtocolRegistry, addressRegistry, certificateStore, loggerFactory)
         {
             _loggerFactory = loggerFactory ?? throw new ArgumentNullException(nameof(loggerFactory));
             _logger = _loggerFactory.CreateLogger(nameof(MessagingServer));
@@ -131,7 +131,7 @@ namespace Helsenorge.Messaging
             IAddressRegistry addressRegistry,
             ICertificateStore certificateStore,
             ICertificateValidator certificateValidator,
-            IMessageProtection messageProtection) : base(settings, collaborationProtocolRegistry, addressRegistry, certificateStore, certificateValidator, messageProtection)
+            IMessageProtection messageProtection) : base(settings, collaborationProtocolRegistry, addressRegistry, certificateStore, certificateValidator, messageProtection, loggerFactory)
         {
             _loggerFactory = loggerFactory ?? throw new ArgumentNullException(nameof(loggerFactory));
             _logger = _loggerFactory.CreateLogger(nameof(MessagingServer));

--- a/src/Helsenorge.Messaging/Security/NoMessageProtection.cs
+++ b/src/Helsenorge.Messaging/Security/NoMessageProtection.cs
@@ -58,9 +58,8 @@ namespace Helsenorge.Messaging.Security
         /// </summary>
         /// <param name="data">A <see cref="Stream"/> containing the data which be decrypted and then the signature will be verified.</param>
         /// <param name="signingCertificate">Not relevant for this implemenation</param>
-        /// <param name="logger"></param>
         /// <returns>A <see cref="Stream"/> containing the data in decrypted form.</returns>
-        public Stream Unprotect(Stream data, X509Certificate2 signingCertificate, ILogger logger)
+        public Stream Unprotect(Stream data, X509Certificate2 signingCertificate)
         {
             if (data == null) throw new ArgumentNullException(nameof(data));
 

--- a/src/Helsenorge.Messaging/Security/NoMessageProtection.cs
+++ b/src/Helsenorge.Messaging/Security/NoMessageProtection.cs
@@ -10,6 +10,7 @@ using System;
 using System.IO;
 using System.Security.Cryptography.X509Certificates;
 using Helsenorge.Messaging.Abstractions;
+using Microsoft.Extensions.Logging;
 
 namespace Helsenorge.Messaging.Security
 {
@@ -57,8 +58,9 @@ namespace Helsenorge.Messaging.Security
         /// </summary>
         /// <param name="data">A <see cref="Stream"/> containing the data which be decrypted and then the signature will be verified.</param>
         /// <param name="signingCertificate">Not relevant for this implemenation</param>
+        /// <param name="logger"></param>
         /// <returns>A <see cref="Stream"/> containing the data in decrypted form.</returns>
-        public Stream Unprotect(Stream data, X509Certificate2 signingCertificate)
+        public Stream Unprotect(Stream data, X509Certificate2 signingCertificate, ILogger logger)
         {
             if (data == null) throw new ArgumentNullException(nameof(data));
 

--- a/src/Helsenorge.Messaging/Security/SignThenEncryptMessageProtection.cs
+++ b/src/Helsenorge.Messaging/Security/SignThenEncryptMessageProtection.cs
@@ -130,8 +130,8 @@ namespace Helsenorge.Messaging.Security
             envelopedCms.Decode(data);
             try
             {
-                var encryptionOid = envelopedCms.ContentEncryptionAlgorithm.Oid;
-                _logger.LogInformation($"Decrypting EnvelopedCms with ContentEncryptionAlgorithm: {encryptionOid.FriendlyName} : {encryptionOid.Value}");
+                var encryptionOid = envelopedCms?.ContentEncryptionAlgorithm?.Oid;
+                _logger.LogInformation($"Decrypting EnvelopedCms with ContentEncryptionAlgorithm: {encryptionOid?.FriendlyName ?? "null"} : {encryptionOid?.Value ?? "null"}");
 
                 envelopedCms.Decrypt(envelopedCms.RecipientInfos[0], encryptionCertificates);
             }

--- a/test/Helsenorge.Messaging.Tests/Amqp/Receivers/AsynchronousReceiveTests.cs
+++ b/test/Helsenorge.Messaging.Tests/Amqp/Receivers/AsynchronousReceiveTests.cs
@@ -686,7 +686,7 @@ namespace Helsenorge.Messaging.Tests.Amqp.Receivers
                 return data;
             }
 
-            public Stream Unprotect(Stream data, X509Certificate2 signingCertificate)
+            public Stream Unprotect(Stream data, X509Certificate2 signingCertificate, ILogger logger)
             {
                 throw new SecurityException("Invalid certificate");
             }

--- a/test/Helsenorge.Messaging.Tests/Amqp/Receivers/AsynchronousReceiveTests.cs
+++ b/test/Helsenorge.Messaging.Tests/Amqp/Receivers/AsynchronousReceiveTests.cs
@@ -76,11 +76,11 @@ namespace Helsenorge.Messaging.Tests.Amqp.Receivers
         {
             Exception receiveException = null;
 
-            var partyAProtection = new SignThenEncryptMessageProtection(TestCertificates.GetCertificate(TestCertificates.CounterpartySignatureThumbprint), TestCertificates.GetCertificate(TestCertificates.CounterpartyEncryptionThumbprint));
+            var partyAProtection = new SignThenEncryptMessageProtection(TestCertificates.GetCertificate(TestCertificates.CounterpartySignatureThumbprint), TestCertificates.GetCertificate(TestCertificates.CounterpartyEncryptionThumbprint), Logger);
             Client = new MessagingClient(Settings, LoggerFactory, CollaborationRegistry, AddressRegistry, CertificateStore, CertificateValidator, partyAProtection);
             Client.AmqpCore.RegisterAlternateMessagingFactory(MockFactory);
 
-            var partyBProtection = new SignThenEncryptMessageProtection(TestCertificates.GetCertificate(TestCertificates.HelsenorgeSignatureThumbprint), TestCertificates.GetCertificate(TestCertificates.HelsenorgeEncryptionThumbprint));
+            var partyBProtection = new SignThenEncryptMessageProtection(TestCertificates.GetCertificate(TestCertificates.HelsenorgeSignatureThumbprint), TestCertificates.GetCertificate(TestCertificates.HelsenorgeEncryptionThumbprint), Logger);
             Server = new MockMessagingServer(Settings, LoggerFactory, CollaborationRegistry, AddressRegistry, CertificateStore, CertificateValidator, partyBProtection);
             Server.AmqpCore.RegisterAlternateMessagingFactory(MockFactory);
 
@@ -686,7 +686,7 @@ namespace Helsenorge.Messaging.Tests.Amqp.Receivers
                 return data;
             }
 
-            public Stream Unprotect(Stream data, X509Certificate2 signingCertificate, ILogger logger)
+            public Stream Unprotect(Stream data, X509Certificate2 signingCertificate)
             {
                 throw new SecurityException("Invalid certificate");
             }
@@ -793,7 +793,7 @@ namespace Helsenorge.Messaging.Tests.Amqp.Receivers
         
         private MockMessage CreateAsynchronousMessageProtected()
         {
-            var messageProtection = new SignThenEncryptMessageProtection(TestCertificates.GetCertificate(TestCertificates.HelsenorgeSignatureThumbprint), TestCertificates.GetCertificate(TestCertificates.HelsenorgeEncryptionThumbprint));
+            var messageProtection = new SignThenEncryptMessageProtection(TestCertificates.GetCertificate(TestCertificates.HelsenorgeSignatureThumbprint), TestCertificates.GetCertificate(TestCertificates.HelsenorgeEncryptionThumbprint), Logger);
             var messageId = Guid.NewGuid().ToString("D");
             var path = Path.Combine("Files", "Helsenorge_Message.xml");
             var file = File.Exists(path) ? new XDocument(XElement.Load(path)) : null;

--- a/test/Helsenorge.Messaging.Tests/Mocks/MockMessageProtection.cs
+++ b/test/Helsenorge.Messaging.Tests/Mocks/MockMessageProtection.cs
@@ -7,6 +7,7 @@
  */
 
 using Helsenorge.Messaging.Abstractions;
+using Microsoft.Extensions.Logging;
 using System.IO;
 using System.Security.Cryptography.X509Certificates;
 
@@ -24,7 +25,7 @@ namespace Helsenorge.Messaging.Tests.Mocks
             return data;
         }
 
-        public override Stream Unprotect(Stream data, X509Certificate2 signingCertificate)
+        public override Stream Unprotect(Stream data, X509Certificate2 signingCertificate, ILogger logger)
         {
             return data;
         }

--- a/test/Helsenorge.Messaging.Tests/Mocks/MockMessageProtection.cs
+++ b/test/Helsenorge.Messaging.Tests/Mocks/MockMessageProtection.cs
@@ -25,7 +25,7 @@ namespace Helsenorge.Messaging.Tests.Mocks
             return data;
         }
 
-        public override Stream Unprotect(Stream data, X509Certificate2 signingCertificate, ILogger logger)
+        public override Stream Unprotect(Stream data, X509Certificate2 signingCertificate)
         {
             return data;
         }

--- a/test/Helsenorge.Messaging.Tests/Security/SignThenEncryptMessageProtectionTests.cs
+++ b/test/Helsenorge.Messaging.Tests/Security/SignThenEncryptMessageProtectionTests.cs
@@ -41,8 +41,10 @@ namespace Helsenorge.Messaging.Tests.Security
             var partyBProtection = new SignThenEncryptMessageProtection(TestCertificates.GetCertificate(TestCertificates.HelsenorgeSignatureThumbprint), TestCertificates.GetCertificate(TestCertificates.HelsenorgeEncryptionThumbprint));
             var result = partyBProtection.Unprotect(
                 stream, 
-                TestCertificates.GetCertificate(TestCertificates.CounterpartySignatureThumbprint));
-            
+                TestCertificates.GetCertificate(TestCertificates.CounterpartySignatureThumbprint),
+                new MockLogger("MockLogger", filter:null));
+
+
             Assert.AreEqual(_content.ToString(), result.ToXDocument().ToString());
         }
 
@@ -59,7 +61,10 @@ namespace Helsenorge.Messaging.Tests.Security
                 TestCertificates.GetCertificate(TestCertificates.HelsenorgeSignatureThumbprint),
                 TestCertificates.GetCertificate(TestCertificates.HelsenorgeEncryptionThumbprint),
                 TestCertificates.GetCertificate(TestCertificates.HelsenorgeLegacyEncryptionThumbprint));  // Legacy certificate
-            var result = partyBProtection.Unprotect(stream, TestCertificates.GetCertificate(TestCertificates.CounterpartySignatureThumbprint));
+            var result = partyBProtection.Unprotect(
+                stream, 
+                TestCertificates.GetCertificate(TestCertificates.CounterpartySignatureThumbprint),
+                new MockLogger("MockLogger", filter: null));
 
             Assert.AreEqual(_content.ToString(), result.ToXDocument().ToString());
         }
@@ -77,7 +82,10 @@ namespace Helsenorge.Messaging.Tests.Security
             var stream = partyAProtection.Protect(contentStream, TestCertificates.GetCertificate(TestCertificates.HelsenorgeEncryptionThumbprint));
             
             var partyBProtection = new SignThenEncryptMessageProtection(TestCertificates.GetCertificate(TestCertificates.HelsenorgeSignatureThumbprint), TestCertificates.GetCertificate(TestCertificates.HelsenorgeEncryptionThumbprint));
-            var result = partyBProtection.Unprotect(stream, wrongCertificate);
+            var result = partyBProtection.Unprotect(
+                stream, 
+                wrongCertificate,
+                new MockLogger("MockLogger", filter: null));
         }
 
         [TestMethod]
@@ -92,7 +100,10 @@ namespace Helsenorge.Messaging.Tests.Security
             var stream = partyAProtection.Protect(contentStream, TestCertificates.GetCertificate(TestCertificates.CounterpartyEncryptionThumbprint));
 
             var partyBProtection = new SignThenEncryptMessageProtection(TestCertificates.GetCertificate(TestCertificates.HelsenorgeSignatureThumbprint), TestCertificates.GetCertificate(TestCertificates.HelsenorgeEncryptionThumbprint));
-            var result = partyBProtection.Unprotect(stream, TestCertificates.GetCertificate(TestCertificates.CounterpartySignatureThumbprint));
+            var result = partyBProtection.Unprotect(
+                stream, 
+                TestCertificates.GetCertificate(TestCertificates.CounterpartySignatureThumbprint),
+                new MockLogger("MockLogger", filter: null));
         }
 
         [TestMethod]
@@ -126,7 +137,10 @@ namespace Helsenorge.Messaging.Tests.Security
         public void Unprotect_Data_ArgumentNullException()
         {
             var partyBProtection = new SignThenEncryptMessageProtection(TestCertificates.GetCertificate(TestCertificates.CounterpartySignatureThumbprint), TestCertificates.GetCertificate(TestCertificates.CounterpartyEncryptionThumbprint));
-            partyBProtection.Unprotect(null, TestCertificates.GetCertificate(TestCertificates.CounterpartySignatureThumbprint));
+            partyBProtection.Unprotect(
+                null, 
+                TestCertificates.GetCertificate(TestCertificates.CounterpartySignatureThumbprint),
+                new MockLogger("MockLogger", filter: null));
         }
 
         [TestMethod]
@@ -147,7 +161,10 @@ namespace Helsenorge.Messaging.Tests.Security
             var stream = partyAProtection.Protect(contentStream, TestCertificates.GetCertificate(TestCertificates.HelsenorgeEncryptionThumbprint));
 
             var partyBProtection = new SignThenEncryptMessageProtection(TestCertificates.GetCertificate(TestCertificates.HelsenorgeSignatureThumbprint), TestCertificates.GetCertificate(TestCertificates.HelsenorgeEncryptionThumbprint));
-            var result = partyBProtection.Unprotect(stream, null);
+            var result = partyBProtection.Unprotect(
+                stream, 
+                null,
+                new MockLogger("MockLogger", filter: null));
 
             Assert.AreEqual(_content.ToString(), result.ToXDocument().ToString());
         }

--- a/test/Helsenorge.Messaging.Tests/Security/SignThenEncryptMessageProtectionTests.cs
+++ b/test/Helsenorge.Messaging.Tests/Security/SignThenEncryptMessageProtectionTests.cs
@@ -47,7 +47,6 @@ namespace Helsenorge.Messaging.Tests.Security
                 stream,
                 TestCertificates.GetCertificate(TestCertificates.CounterpartySignatureThumbprint));
 
-
             Assert.AreEqual(_content.ToString(), result.ToXDocument().ToString());
         }
 
@@ -81,7 +80,6 @@ namespace Helsenorge.Messaging.Tests.Security
             const string wrongCertificateBase64 = "MIIE3jCCA8agAwIBAgILCE2BUrKlJGrOxOgwDQYJKoZIhvcNAQELBQAwSzELMAkGA1UEBhMCTk8xHTAbBgNVBAoMFEJ1eXBhc3MgQVMtOTgzMTYzMzI3MR0wGwYDVQQDDBRCdXlwYXNzIENsYXNzIDMgQ0EgMzAeFw0xNjAxMTgwOTA3NTZaFw0xOTAxMTgyMjU5MDBaMHIxCzAJBgNVBAYTAk5PMRswGQYDVQQKDBJOT1JTSyBIRUxTRU5FVFQgU0YxFTATBgNVBAsMDFRFU1RTRU5URVJFVDEbMBkGA1UEAwwSTk9SU0sgSEVMU0VORVRUIFNGMRIwEAYDVQQFEwk5OTQ1OTg3NTkwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCZ34VMBCzmHwmvMWwq0YhtNaEz19PxcEq3ImbCLWZx0zIf2hp8ZSDQy23KpgTumrTebeXEW5b1ig4THXizKzDtwirV5ssO441U7hvTXr+Bm1GYpRc1Q0vzZbKg41Nje5cq+kAovq3H8nnJ3csdjFS5QWKKz1hyUL9V6mZiR1eMVLWbOL2gBR6rjB0OgpoXtF9wmb2Z9So+srAyqnpRy9xBumBFdqvx3+8iZp8G9FH0TPgzeEPreLX5tdKZL0J/Z7+zWXqCx+Fu1PoKMkdw+aYJCVtUJPRXY1t4BpLKO0h6yXf7Rpky+sUQcJmKyagOBPZr9mqqjycYQg6JPSkcTo+XAgMBAAGjggGaMIIBljAJBgNVHRMEAjAAMB8GA1UdIwQYMBaAFMzD+Ae3nG16TvWnKx0F+bNHHJHRMB0GA1UdDgQWBBRpioossQ08OgpOuAl6/58qpAkvajAOBgNVHQ8BAf8EBAMCBkAwFQYDVR0gBA4wDDAKBghghEIBGgEDAjCBpQYDVR0fBIGdMIGaMC+gLaArhilodHRwOi8vY3JsLmJ1eXBhc3Mubm8vY3JsL0JQQ2xhc3MzQ0EzLmNybDBnoGWgY4ZhbGRhcDovL2xkYXAuYnV5cGFzcy5uby9kYz1CdXlwYXNzLGRjPU5PLENOPUJ1eXBhc3MlMjBDbGFzcyUyMDMlMjBDQSUyMDM/Y2VydGlmaWNhdGVSZXZvY2F0aW9uTGlzdDB6BggrBgEFBQcBAQRuMGwwMwYIKwYBBQUHMAGGJ2h0dHA6Ly9vY3NwLmJ1eXBhc3Mubm8vb2NzcC9CUENsYXNzM0NBMzA1BggrBgEFBQcwAoYpaHR0cDovL2NydC5idXlwYXNzLm5vL2NydC9CUENsYXNzM0NBMy5jZXIwDQYJKoZIhvcNAQELBQADggEBALPuCmA93Mi9NZFUFOaQz3PasTFLeLmtSXtt4Qp0TVtJuhqrlDeWYXDCsffMQoCAZXE3569/hdEgHPBVALo8xKS9vdwZR5SgIF+IivsEdC4ZYsq8C5VX4qq2WxW7yHNy3GYU8RBdOaztTfUliv7uaAeooP6EOPa6m+R+dgGfGnb5rM8NRyGgcAKDvC1YUFwdWaIgqO0gBB6WnSkhkyk0iX4tksUkbemQFcyMi2XDog6IFpkYt85MvfBklwjjufCiIcpkzHmuZCcYSLdwqi40Cz4QM5FE8zQYJJLco35A7NVW3MusyFImTleOlL10NH3XnqeLM8loa1Ph7YPl0SpiSjY=";
             var wrongCertificate = new X509Certificate2(Convert.FromBase64String(wrongCertificateBase64));
             MemoryStream contentStream = new MemoryStream(Encoding.UTF8.GetBytes(_content.ToString()));
-            
 
             var partyAProtection = new SignThenEncryptMessageProtection(TestCertificates.GetCertificate(TestCertificates.CounterpartySignatureThumbprint), TestCertificates.GetCertificate(TestCertificates.CounterpartyEncryptionThumbprint), _logger);
             var stream = partyAProtection.Protect(contentStream, TestCertificates.GetCertificate(TestCertificates.HelsenorgeEncryptionThumbprint));
@@ -98,7 +96,6 @@ namespace Helsenorge.Messaging.Tests.Security
         public void Protect_And_Unprotect_WrongEncryptionCertificate()
         {
             MemoryStream contentStream = new MemoryStream(Encoding.UTF8.GetBytes(_content.ToString()));
-            
 
             var partyAProtection = new SignThenEncryptMessageProtection(TestCertificates.GetCertificate(TestCertificates.CounterpartySignatureThumbprint), TestCertificates.GetCertificate(TestCertificates.CounterpartyEncryptionThumbprint), _logger);
             // Random encryption certificate -> TestCertificates.CounterpartyPublicEncryption
@@ -114,7 +111,6 @@ namespace Helsenorge.Messaging.Tests.Security
         [ExpectedException(typeof(ArgumentNullException))]
         public void Protect_Data_ArgumentNullException()
         {
-            
             var partyAProtection = new SignThenEncryptMessageProtection(TestCertificates.GetCertificate(TestCertificates.CounterpartySignatureThumbprint), TestCertificates.GetCertificate(TestCertificates.CounterpartyEncryptionThumbprint), _logger);
             partyAProtection.Protect(null, TestCertificates.GetCertificate(TestCertificates.HelsenorgeEncryptionThumbprint));
         }
@@ -124,7 +120,6 @@ namespace Helsenorge.Messaging.Tests.Security
         public void Protect_Encryption_ArgumentNullException()
         {
             MemoryStream contentStream = new MemoryStream(Encoding.UTF8.GetBytes(_content.ToString()));
-            
 
             var partyAProtection = new SignThenEncryptMessageProtection(TestCertificates.GetCertificate(TestCertificates.CounterpartySignatureThumbprint), TestCertificates.GetCertificate(TestCertificates.CounterpartyEncryptionThumbprint), _logger);
             partyAProtection.Protect(contentStream, null);
@@ -134,7 +129,6 @@ namespace Helsenorge.Messaging.Tests.Security
         [ExpectedException(typeof(ArgumentNullException))]
         public void Protect_Signature_ArgumentNullException()
         {
-            
             new SignThenEncryptMessageProtection(null, TestCertificates.GetCertificate(TestCertificates.CounterpartyEncryptionThumbprint), _logger);
         }
 
@@ -143,7 +137,6 @@ namespace Helsenorge.Messaging.Tests.Security
         [TestCategory("X509Chain")]
         public void Unprotect_Data_ArgumentNullException()
         {
-            
             var partyBProtection = new SignThenEncryptMessageProtection(TestCertificates.GetCertificate(TestCertificates.CounterpartySignatureThumbprint), TestCertificates.GetCertificate(TestCertificates.CounterpartyEncryptionThumbprint), _logger);
             partyBProtection.Unprotect(
                 null,
@@ -155,7 +148,6 @@ namespace Helsenorge.Messaging.Tests.Security
         [TestCategory("X509Chain")]
         public void Unprotect_Encryption_ArgumentNullException()
         {
-            
             new SignThenEncryptMessageProtection(TestCertificates.GetCertificate(TestCertificates.HelsenorgeSignatureThumbprint), null, _logger);
         }
 
@@ -164,7 +156,6 @@ namespace Helsenorge.Messaging.Tests.Security
         public void Unprotect_Signature_MissingPublicKeySignatureCertificate()
         {
             MemoryStream contentStream = new MemoryStream(Encoding.UTF8.GetBytes(_content.ToString()));
-            
 
             var partyAProtection = new SignThenEncryptMessageProtection(TestCertificates.GetCertificate(TestCertificates.CounterpartySignatureThumbprint), TestCertificates.GetCertificate(TestCertificates.CounterpartyEncryptionThumbprint), _logger);
             var stream = partyAProtection.Protect(contentStream, TestCertificates.GetCertificate(TestCertificates.HelsenorgeEncryptionThumbprint));

--- a/test/Helsenorge.Messaging.Tests/Security/SignThenEncryptMessageProtectionTests.cs
+++ b/test/Helsenorge.Messaging.Tests/Security/SignThenEncryptMessageProtectionTests.cs
@@ -15,6 +15,7 @@ using System.Xml.Linq;
 using Helsenorge.Messaging.Abstractions;
 using Helsenorge.Messaging.Security;
 using Helsenorge.Messaging.Tests.Mocks;
+using Microsoft.Extensions.Logging;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Helsenorge.Messaging.Tests.Security
@@ -23,10 +24,13 @@ namespace Helsenorge.Messaging.Tests.Security
     public class SignThenEncryptMessageProtectionTests
     {
         private XDocument _content;
+        private ILogger _logger;
         [TestInitialize]
         public void Setup()
         {
             _content = new XDocument(new XElement("SomeDummyXml"));
+            var provider = new MockLoggerProvider(null);
+            _logger = provider.CreateLogger("Test logger");
         }
 
         [TestMethod]
@@ -34,15 +38,14 @@ namespace Helsenorge.Messaging.Tests.Security
         public void Protect_And_Unprotect_OK()
         {
             MemoryStream contentStream = new MemoryStream(Encoding.UTF8.GetBytes(_content.ToString()));
-
-            var partyAProtection = new SignThenEncryptMessageProtection(TestCertificates.GetCertificate(TestCertificates.CounterpartySignatureThumbprint), TestCertificates.GetCertificate(TestCertificates.CounterpartyEncryptionThumbprint));
+            
+            var partyAProtection = new SignThenEncryptMessageProtection(TestCertificates.GetCertificate(TestCertificates.CounterpartySignatureThumbprint), TestCertificates.GetCertificate(TestCertificates.CounterpartyEncryptionThumbprint), _logger);
             var stream = partyAProtection.Protect(contentStream, TestCertificates.GetCertificate(TestCertificates.HelsenorgeEncryptionThumbprint));
 
-            var partyBProtection = new SignThenEncryptMessageProtection(TestCertificates.GetCertificate(TestCertificates.HelsenorgeSignatureThumbprint), TestCertificates.GetCertificate(TestCertificates.HelsenorgeEncryptionThumbprint));
+            var partyBProtection = new SignThenEncryptMessageProtection(TestCertificates.GetCertificate(TestCertificates.HelsenorgeSignatureThumbprint), TestCertificates.GetCertificate(TestCertificates.HelsenorgeEncryptionThumbprint), _logger);
             var result = partyBProtection.Unprotect(
-                stream, 
-                TestCertificates.GetCertificate(TestCertificates.CounterpartySignatureThumbprint),
-                new MockLogger("MockLogger", filter:null));
+                stream,
+                TestCertificates.GetCertificate(TestCertificates.CounterpartySignatureThumbprint));
 
 
             Assert.AreEqual(_content.ToString(), result.ToXDocument().ToString());
@@ -53,18 +56,19 @@ namespace Helsenorge.Messaging.Tests.Security
         public void Protect_And_Unprotect_UsingLegacy_OK()
         {
             MemoryStream contentStream = new MemoryStream(Encoding.UTF8.GetBytes(_content.ToString()));
-
-            var partyAProtection = new SignThenEncryptMessageProtection(TestCertificates.GetCertificate(TestCertificates.CounterpartySignatureThumbprint), TestCertificates.GetCertificate(TestCertificates.CounterpartyEncryptionThumbprint));
+            
+            var partyAProtection = new SignThenEncryptMessageProtection(TestCertificates.GetCertificate(TestCertificates.CounterpartySignatureThumbprint), TestCertificates.GetCertificate(TestCertificates.CounterpartyEncryptionThumbprint), _logger);
             var stream = partyAProtection.Protect(contentStream, TestCertificates.GetCertificate(TestCertificates.HelsenorgeLegacyEncryptionThumbprint));
 
             var partyBProtection = new SignThenEncryptMessageProtection(
                 TestCertificates.GetCertificate(TestCertificates.HelsenorgeSignatureThumbprint),
                 TestCertificates.GetCertificate(TestCertificates.HelsenorgeEncryptionThumbprint),
+                _logger,
                 TestCertificates.GetCertificate(TestCertificates.HelsenorgeLegacyEncryptionThumbprint));  // Legacy certificate
+
             var result = partyBProtection.Unprotect(
-                stream, 
-                TestCertificates.GetCertificate(TestCertificates.CounterpartySignatureThumbprint),
-                new MockLogger("MockLogger", filter: null));
+                stream,
+                TestCertificates.GetCertificate(TestCertificates.CounterpartySignatureThumbprint));
 
             Assert.AreEqual(_content.ToString(), result.ToXDocument().ToString());
         }
@@ -77,15 +81,15 @@ namespace Helsenorge.Messaging.Tests.Security
             const string wrongCertificateBase64 = "MIIE3jCCA8agAwIBAgILCE2BUrKlJGrOxOgwDQYJKoZIhvcNAQELBQAwSzELMAkGA1UEBhMCTk8xHTAbBgNVBAoMFEJ1eXBhc3MgQVMtOTgzMTYzMzI3MR0wGwYDVQQDDBRCdXlwYXNzIENsYXNzIDMgQ0EgMzAeFw0xNjAxMTgwOTA3NTZaFw0xOTAxMTgyMjU5MDBaMHIxCzAJBgNVBAYTAk5PMRswGQYDVQQKDBJOT1JTSyBIRUxTRU5FVFQgU0YxFTATBgNVBAsMDFRFU1RTRU5URVJFVDEbMBkGA1UEAwwSTk9SU0sgSEVMU0VORVRUIFNGMRIwEAYDVQQFEwk5OTQ1OTg3NTkwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCZ34VMBCzmHwmvMWwq0YhtNaEz19PxcEq3ImbCLWZx0zIf2hp8ZSDQy23KpgTumrTebeXEW5b1ig4THXizKzDtwirV5ssO441U7hvTXr+Bm1GYpRc1Q0vzZbKg41Nje5cq+kAovq3H8nnJ3csdjFS5QWKKz1hyUL9V6mZiR1eMVLWbOL2gBR6rjB0OgpoXtF9wmb2Z9So+srAyqnpRy9xBumBFdqvx3+8iZp8G9FH0TPgzeEPreLX5tdKZL0J/Z7+zWXqCx+Fu1PoKMkdw+aYJCVtUJPRXY1t4BpLKO0h6yXf7Rpky+sUQcJmKyagOBPZr9mqqjycYQg6JPSkcTo+XAgMBAAGjggGaMIIBljAJBgNVHRMEAjAAMB8GA1UdIwQYMBaAFMzD+Ae3nG16TvWnKx0F+bNHHJHRMB0GA1UdDgQWBBRpioossQ08OgpOuAl6/58qpAkvajAOBgNVHQ8BAf8EBAMCBkAwFQYDVR0gBA4wDDAKBghghEIBGgEDAjCBpQYDVR0fBIGdMIGaMC+gLaArhilodHRwOi8vY3JsLmJ1eXBhc3Mubm8vY3JsL0JQQ2xhc3MzQ0EzLmNybDBnoGWgY4ZhbGRhcDovL2xkYXAuYnV5cGFzcy5uby9kYz1CdXlwYXNzLGRjPU5PLENOPUJ1eXBhc3MlMjBDbGFzcyUyMDMlMjBDQSUyMDM/Y2VydGlmaWNhdGVSZXZvY2F0aW9uTGlzdDB6BggrBgEFBQcBAQRuMGwwMwYIKwYBBQUHMAGGJ2h0dHA6Ly9vY3NwLmJ1eXBhc3Mubm8vb2NzcC9CUENsYXNzM0NBMzA1BggrBgEFBQcwAoYpaHR0cDovL2NydC5idXlwYXNzLm5vL2NydC9CUENsYXNzM0NBMy5jZXIwDQYJKoZIhvcNAQELBQADggEBALPuCmA93Mi9NZFUFOaQz3PasTFLeLmtSXtt4Qp0TVtJuhqrlDeWYXDCsffMQoCAZXE3569/hdEgHPBVALo8xKS9vdwZR5SgIF+IivsEdC4ZYsq8C5VX4qq2WxW7yHNy3GYU8RBdOaztTfUliv7uaAeooP6EOPa6m+R+dgGfGnb5rM8NRyGgcAKDvC1YUFwdWaIgqO0gBB6WnSkhkyk0iX4tksUkbemQFcyMi2XDog6IFpkYt85MvfBklwjjufCiIcpkzHmuZCcYSLdwqi40Cz4QM5FE8zQYJJLco35A7NVW3MusyFImTleOlL10NH3XnqeLM8loa1Ph7YPl0SpiSjY=";
             var wrongCertificate = new X509Certificate2(Convert.FromBase64String(wrongCertificateBase64));
             MemoryStream contentStream = new MemoryStream(Encoding.UTF8.GetBytes(_content.ToString()));
-
-            var partyAProtection = new SignThenEncryptMessageProtection(TestCertificates.GetCertificate(TestCertificates.CounterpartySignatureThumbprint), TestCertificates.GetCertificate(TestCertificates.CounterpartyEncryptionThumbprint));
-            var stream = partyAProtection.Protect(contentStream, TestCertificates.GetCertificate(TestCertificates.HelsenorgeEncryptionThumbprint));
             
-            var partyBProtection = new SignThenEncryptMessageProtection(TestCertificates.GetCertificate(TestCertificates.HelsenorgeSignatureThumbprint), TestCertificates.GetCertificate(TestCertificates.HelsenorgeEncryptionThumbprint));
+
+            var partyAProtection = new SignThenEncryptMessageProtection(TestCertificates.GetCertificate(TestCertificates.CounterpartySignatureThumbprint), TestCertificates.GetCertificate(TestCertificates.CounterpartyEncryptionThumbprint), _logger);
+            var stream = partyAProtection.Protect(contentStream, TestCertificates.GetCertificate(TestCertificates.HelsenorgeEncryptionThumbprint));
+
+            var partyBProtection = new SignThenEncryptMessageProtection(TestCertificates.GetCertificate(TestCertificates.HelsenorgeSignatureThumbprint), TestCertificates.GetCertificate(TestCertificates.HelsenorgeEncryptionThumbprint), _logger);
             var result = partyBProtection.Unprotect(
-                stream, 
-                wrongCertificate,
-                new MockLogger("MockLogger", filter: null));
+                stream,
+                wrongCertificate);
         }
 
         [TestMethod]
@@ -94,23 +98,24 @@ namespace Helsenorge.Messaging.Tests.Security
         public void Protect_And_Unprotect_WrongEncryptionCertificate()
         {
             MemoryStream contentStream = new MemoryStream(Encoding.UTF8.GetBytes(_content.ToString()));
+            
 
-            var partyAProtection = new SignThenEncryptMessageProtection(TestCertificates.GetCertificate(TestCertificates.CounterpartySignatureThumbprint), TestCertificates.GetCertificate(TestCertificates.CounterpartyEncryptionThumbprint));
+            var partyAProtection = new SignThenEncryptMessageProtection(TestCertificates.GetCertificate(TestCertificates.CounterpartySignatureThumbprint), TestCertificates.GetCertificate(TestCertificates.CounterpartyEncryptionThumbprint), _logger);
             // Random encryption certificate -> TestCertificates.CounterpartyPublicEncryption
             var stream = partyAProtection.Protect(contentStream, TestCertificates.GetCertificate(TestCertificates.CounterpartyEncryptionThumbprint));
 
-            var partyBProtection = new SignThenEncryptMessageProtection(TestCertificates.GetCertificate(TestCertificates.HelsenorgeSignatureThumbprint), TestCertificates.GetCertificate(TestCertificates.HelsenorgeEncryptionThumbprint));
+            var partyBProtection = new SignThenEncryptMessageProtection(TestCertificates.GetCertificate(TestCertificates.HelsenorgeSignatureThumbprint), TestCertificates.GetCertificate(TestCertificates.HelsenorgeEncryptionThumbprint), _logger);
             var result = partyBProtection.Unprotect(
-                stream, 
-                TestCertificates.GetCertificate(TestCertificates.CounterpartySignatureThumbprint),
-                new MockLogger("MockLogger", filter: null));
+                stream,
+                TestCertificates.GetCertificate(TestCertificates.CounterpartySignatureThumbprint));
         }
 
         [TestMethod]
         [ExpectedException(typeof(ArgumentNullException))]
         public void Protect_Data_ArgumentNullException()
         {
-            var partyAProtection = new SignThenEncryptMessageProtection(TestCertificates.GetCertificate(TestCertificates.CounterpartySignatureThumbprint), TestCertificates.GetCertificate(TestCertificates.CounterpartyEncryptionThumbprint));
+            
+            var partyAProtection = new SignThenEncryptMessageProtection(TestCertificates.GetCertificate(TestCertificates.CounterpartySignatureThumbprint), TestCertificates.GetCertificate(TestCertificates.CounterpartyEncryptionThumbprint), _logger);
             partyAProtection.Protect(null, TestCertificates.GetCertificate(TestCertificates.HelsenorgeEncryptionThumbprint));
         }
 
@@ -119,8 +124,9 @@ namespace Helsenorge.Messaging.Tests.Security
         public void Protect_Encryption_ArgumentNullException()
         {
             MemoryStream contentStream = new MemoryStream(Encoding.UTF8.GetBytes(_content.ToString()));
+            
 
-            var partyAProtection = new SignThenEncryptMessageProtection(TestCertificates.GetCertificate(TestCertificates.CounterpartySignatureThumbprint), TestCertificates.GetCertificate(TestCertificates.CounterpartyEncryptionThumbprint));
+            var partyAProtection = new SignThenEncryptMessageProtection(TestCertificates.GetCertificate(TestCertificates.CounterpartySignatureThumbprint), TestCertificates.GetCertificate(TestCertificates.CounterpartyEncryptionThumbprint), _logger);
             partyAProtection.Protect(contentStream, null);
         }
 
@@ -128,7 +134,8 @@ namespace Helsenorge.Messaging.Tests.Security
         [ExpectedException(typeof(ArgumentNullException))]
         public void Protect_Signature_ArgumentNullException()
         {
-            new SignThenEncryptMessageProtection(null, TestCertificates.GetCertificate(TestCertificates.CounterpartyEncryptionThumbprint));
+            
+            new SignThenEncryptMessageProtection(null, TestCertificates.GetCertificate(TestCertificates.CounterpartyEncryptionThumbprint), _logger);
         }
 
         [TestMethod]
@@ -136,11 +143,11 @@ namespace Helsenorge.Messaging.Tests.Security
         [TestCategory("X509Chain")]
         public void Unprotect_Data_ArgumentNullException()
         {
-            var partyBProtection = new SignThenEncryptMessageProtection(TestCertificates.GetCertificate(TestCertificates.CounterpartySignatureThumbprint), TestCertificates.GetCertificate(TestCertificates.CounterpartyEncryptionThumbprint));
+            
+            var partyBProtection = new SignThenEncryptMessageProtection(TestCertificates.GetCertificate(TestCertificates.CounterpartySignatureThumbprint), TestCertificates.GetCertificate(TestCertificates.CounterpartyEncryptionThumbprint), _logger);
             partyBProtection.Unprotect(
-                null, 
-                TestCertificates.GetCertificate(TestCertificates.CounterpartySignatureThumbprint),
-                new MockLogger("MockLogger", filter: null));
+                null,
+                TestCertificates.GetCertificate(TestCertificates.CounterpartySignatureThumbprint));
         }
 
         [TestMethod]
@@ -148,7 +155,8 @@ namespace Helsenorge.Messaging.Tests.Security
         [TestCategory("X509Chain")]
         public void Unprotect_Encryption_ArgumentNullException()
         {
-            new SignThenEncryptMessageProtection(TestCertificates.GetCertificate(TestCertificates.HelsenorgeSignatureThumbprint), null);
+            
+            new SignThenEncryptMessageProtection(TestCertificates.GetCertificate(TestCertificates.HelsenorgeSignatureThumbprint), null, _logger);
         }
 
         [TestMethod]
@@ -156,15 +164,15 @@ namespace Helsenorge.Messaging.Tests.Security
         public void Unprotect_Signature_MissingPublicKeySignatureCertificate()
         {
             MemoryStream contentStream = new MemoryStream(Encoding.UTF8.GetBytes(_content.ToString()));
+            
 
-            var partyAProtection = new SignThenEncryptMessageProtection(TestCertificates.GetCertificate(TestCertificates.CounterpartySignatureThumbprint), TestCertificates.GetCertificate(TestCertificates.CounterpartyEncryptionThumbprint));
+            var partyAProtection = new SignThenEncryptMessageProtection(TestCertificates.GetCertificate(TestCertificates.CounterpartySignatureThumbprint), TestCertificates.GetCertificate(TestCertificates.CounterpartyEncryptionThumbprint), _logger);
             var stream = partyAProtection.Protect(contentStream, TestCertificates.GetCertificate(TestCertificates.HelsenorgeEncryptionThumbprint));
 
-            var partyBProtection = new SignThenEncryptMessageProtection(TestCertificates.GetCertificate(TestCertificates.HelsenorgeSignatureThumbprint), TestCertificates.GetCertificate(TestCertificates.HelsenorgeEncryptionThumbprint));
+            var partyBProtection = new SignThenEncryptMessageProtection(TestCertificates.GetCertificate(TestCertificates.HelsenorgeSignatureThumbprint), TestCertificates.GetCertificate(TestCertificates.HelsenorgeEncryptionThumbprint), _logger);
             var result = partyBProtection.Unprotect(
-                stream, 
-                null,
-                new MockLogger("MockLogger", filter: null));
+                stream,
+                null);
 
             Assert.AreEqual(_content.ToString(), result.ToXDocument().ToString());
         }


### PR DESCRIPTION
This is gonna be used for statistics on what encryption types are being used. Will also be used to name and shame software that is using encryption algorithms that are past the EoL