### PR TITLE
Log out what encryption algorithm is being used when unprotecting

### DIFF
--- a/Examples/ReceiveDecryptAndValidate/Program.cs
+++ b/Examples/ReceiveDecryptAndValidate/Program.cs
@@ -44,7 +44,7 @@ namespace ReceiveDecryptAndValidate
                 var certificateStore = new MockCertificateStore();
                 var signatureCertificate = certificateStore.GetCertificate(TestCertificates.CounterpartySignatureThumbprint);
                 var encryptionCertificate = certificateStore.GetCertificate(TestCertificates.CounterpartyEncryptionThumbprint);
-                var messageProtection = new SignThenEncryptMessageProtection(signatureCertificate, encryptionCertificate);
+                var messageProtection = new SignThenEncryptMessageProtection(signatureCertificate, encryptionCertificate, loggerFactory.CreateLogger<SignThenEncryptMessageProtection>());
 
                 var addressRegistry = new MockAddressRegistry();
 

--- a/Examples/SignEncryptAndSend/Program.cs
+++ b/Examples/SignEncryptAndSend/Program.cs
@@ -46,7 +46,7 @@ namespace SignEncryptAndSend
                 var certificateStore = new MockCertificateStore();
                 var signatureCertificate = certificateStore.GetCertificate(TestCertificates.HelsenorgeSignatureThumbprint);
                 var encryptionCertificate = certificateStore.GetCertificate(TestCertificates.HelsenorgeEncryptionThumbprint);
-                var messageProtection = new SignThenEncryptMessageProtection(signatureCertificate, encryptionCertificate);
+                var messageProtection = new SignThenEncryptMessageProtection(signatureCertificate, encryptionCertificate, loggerFactory.CreateLogger<SignThenEncryptMessageProtection>());
 
                 var addressRegistry = new MockAddressRegistry();
 

--- a/src/Helsenorge.Messaging/MessagingClient.cs
+++ b/src/Helsenorge.Messaging/MessagingClient.cs
@@ -40,7 +40,7 @@ namespace Helsenorge.Messaging
             MessagingSettings settings,
             ILoggerFactory loggerFactory,
             ICollaborationProtocolRegistry collaborationProtocolRegistry,
-            IAddressRegistry addressRegistry) : base(settings, collaborationProtocolRegistry, addressRegistry)
+            IAddressRegistry addressRegistry) : base(settings, collaborationProtocolRegistry, addressRegistry, loggerFactory)
         {
             _loggerFactory = loggerFactory ?? throw new ArgumentNullException(nameof(loggerFactory));
             _logger = _loggerFactory.CreateLogger(nameof(MessagingClient));
@@ -61,7 +61,7 @@ namespace Helsenorge.Messaging
             ILoggerFactory loggerFactory,
             ICollaborationProtocolRegistry collaborationProtocolRegistry,
             IAddressRegistry addressRegistry,
-            ICertificateStore certificateStore) : base(settings, collaborationProtocolRegistry, addressRegistry, certificateStore)
+            ICertificateStore certificateStore) : base(settings, collaborationProtocolRegistry, addressRegistry, certificateStore, loggerFactory)
         {
             _loggerFactory = loggerFactory ?? throw new ArgumentNullException(nameof(loggerFactory));
             _logger = _loggerFactory.CreateLogger(nameof(MessagingClient));
@@ -86,7 +86,7 @@ namespace Helsenorge.Messaging
             IAddressRegistry addressRegistry,
             ICertificateStore certificateStore,
             ICertificateValidator certificateValidator,
-            IMessageProtection messageProtection) : base(settings, collaborationProtocolRegistry, addressRegistry, certificateStore, certificateValidator, messageProtection)
+            IMessageProtection messageProtection) : base(settings, collaborationProtocolRegistry, addressRegistry, certificateStore, certificateValidator, messageProtection, loggerFactory)
         {
             _loggerFactory = loggerFactory ?? throw new ArgumentNullException(nameof(loggerFactory));
             _logger = _loggerFactory.CreateLogger(nameof(MessagingClient));

--- a/src/Helsenorge.Messaging/MessagingServer.cs
+++ b/src/Helsenorge.Messaging/MessagingServer.cs
@@ -89,7 +89,7 @@ namespace Helsenorge.Messaging
             MessagingSettings settings,
             ILoggerFactory loggerFactory,
             ICollaborationProtocolRegistry collaborationProtocolRegistry,
-            IAddressRegistry addressRegistry) : base(settings, collaborationProtocolRegistry, addressRegistry)
+            IAddressRegistry addressRegistry) : base(settings, collaborationProtocolRegistry, addressRegistry, loggerFactory)
         {
             _loggerFactory = loggerFactory ?? throw new ArgumentNullException(nameof(loggerFactory));
             _logger = _loggerFactory.CreateLogger(nameof(MessagingServer));
@@ -108,7 +108,7 @@ namespace Helsenorge.Messaging
             ILoggerFactory loggerFactory,
             ICollaborationProtocolRegistry collaborationProtocolRegistry,
             IAddressRegistry addressRegistry,
-            ICertificateStore certificateStore) : base(settings, collaborationProtocolRegistry, addressRegistry, certificateStore)
+            ICertificateStore certificateStore) : base(settings, collaborationProtocolRegistry, addressRegistry, certificateStore, loggerFactory)
         {
             _loggerFactory = loggerFactory ?? throw new ArgumentNullException(nameof(loggerFactory));
             _logger = _loggerFactory.CreateLogger(nameof(MessagingServer));
@@ -131,7 +131,7 @@ namespace Helsenorge.Messaging
             IAddressRegistry addressRegistry,
             ICertificateStore certificateStore,
             ICertificateValidator certificateValidator,
-            IMessageProtection messageProtection) : base(settings, collaborationProtocolRegistry, addressRegistry, certificateStore, certificateValidator, messageProtection)
+            IMessageProtection messageProtection) : base(settings, collaborationProtocolRegistry, addressRegistry, certificateStore, certificateValidator, messageProtection, loggerFactory)
         {
             _loggerFactory = loggerFactory ?? throw new ArgumentNullException(nameof(loggerFactory));
             _logger = _loggerFactory.CreateLogger(nameof(MessagingServer));

--- a/test/Helsenorge.Messaging.Tests/Amqp/Receivers/AsynchronousReceiveTests.cs
+++ b/test/Helsenorge.Messaging.Tests/Amqp/Receivers/AsynchronousReceiveTests.cs
@@ -76,11 +76,11 @@ namespace Helsenorge.Messaging.Tests.Amqp.Receivers
         {
             Exception receiveException = null;
 
-            var partyAProtection = new SignThenEncryptMessageProtection(TestCertificates.GetCertificate(TestCertificates.CounterpartySignatureThumbprint), TestCertificates.GetCertificate(TestCertificates.CounterpartyEncryptionThumbprint));
+            var partyAProtection = new SignThenEncryptMessageProtection(TestCertificates.GetCertificate(TestCertificates.CounterpartySignatureThumbprint), TestCertificates.GetCertificate(TestCertificates.CounterpartyEncryptionThumbprint), Logger);
             Client = new MessagingClient(Settings, LoggerFactory, CollaborationRegistry, AddressRegistry, CertificateStore, CertificateValidator, partyAProtection);
             Client.AmqpCore.RegisterAlternateMessagingFactory(MockFactory);
 
-            var partyBProtection = new SignThenEncryptMessageProtection(TestCertificates.GetCertificate(TestCertificates.HelsenorgeSignatureThumbprint), TestCertificates.GetCertificate(TestCertificates.HelsenorgeEncryptionThumbprint));
+            var partyBProtection = new SignThenEncryptMessageProtection(TestCertificates.GetCertificate(TestCertificates.HelsenorgeSignatureThumbprint), TestCertificates.GetCertificate(TestCertificates.HelsenorgeEncryptionThumbprint), Logger);
             Server = new MockMessagingServer(Settings, LoggerFactory, CollaborationRegistry, AddressRegistry, CertificateStore, CertificateValidator, partyBProtection);
             Server.AmqpCore.RegisterAlternateMessagingFactory(MockFactory);
 
@@ -793,7 +793,7 @@ namespace Helsenorge.Messaging.Tests.Amqp.Receivers
         
         private MockMessage CreateAsynchronousMessageProtected()
         {
-            var messageProtection = new SignThenEncryptMessageProtection(TestCertificates.GetCertificate(TestCertificates.HelsenorgeSignatureThumbprint), TestCertificates.GetCertificate(TestCertificates.HelsenorgeEncryptionThumbprint));
+            var messageProtection = new SignThenEncryptMessageProtection(TestCertificates.GetCertificate(TestCertificates.HelsenorgeSignatureThumbprint), TestCertificates.GetCertificate(TestCertificates.HelsenorgeEncryptionThumbprint), Logger);
             var messageId = Guid.NewGuid().ToString("D");
             var path = Path.Combine("Files", "Helsenorge_Message.xml");
             var file = File.Exists(path) ? new XDocument(XElement.Load(path)) : null;

--- a/test/Helsenorge.Messaging.Tests/Security/SignThenEncryptMessageProtectionTests.cs
+++ b/test/Helsenorge.Messaging.Tests/Security/SignThenEncryptMessageProtectionTests.cs
@@ -15,6 +15,7 @@ using System.Xml.Linq;
 using Helsenorge.Messaging.Abstractions;
 using Helsenorge.Messaging.Security;
 using Helsenorge.Messaging.Tests.Mocks;
+using Microsoft.Extensions.Logging;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Helsenorge.Messaging.Tests.Security
@@ -23,10 +24,13 @@ namespace Helsenorge.Messaging.Tests.Security
     public class SignThenEncryptMessageProtectionTests
     {
         private XDocument _content;
+        private ILogger _logger;
         [TestInitialize]
         public void Setup()
         {
             _content = new XDocument(new XElement("SomeDummyXml"));
+            var mockProvider = new MockLoggerProvider(null);
+            _logger = mockProvider.CreateLogger("Test logger");
         }
 
         [TestMethod]
@@ -35,10 +39,10 @@ namespace Helsenorge.Messaging.Tests.Security
         {
             MemoryStream contentStream = new MemoryStream(Encoding.UTF8.GetBytes(_content.ToString()));
 
-            var partyAProtection = new SignThenEncryptMessageProtection(TestCertificates.GetCertificate(TestCertificates.CounterpartySignatureThumbprint), TestCertificates.GetCertificate(TestCertificates.CounterpartyEncryptionThumbprint));
+            var partyAProtection = new SignThenEncryptMessageProtection(TestCertificates.GetCertificate(TestCertificates.CounterpartySignatureThumbprint), TestCertificates.GetCertificate(TestCertificates.CounterpartyEncryptionThumbprint), _logger);
             var stream = partyAProtection.Protect(contentStream, TestCertificates.GetCertificate(TestCertificates.HelsenorgeEncryptionThumbprint));
 
-            var partyBProtection = new SignThenEncryptMessageProtection(TestCertificates.GetCertificate(TestCertificates.HelsenorgeSignatureThumbprint), TestCertificates.GetCertificate(TestCertificates.HelsenorgeEncryptionThumbprint));
+            var partyBProtection = new SignThenEncryptMessageProtection(TestCertificates.GetCertificate(TestCertificates.HelsenorgeSignatureThumbprint), TestCertificates.GetCertificate(TestCertificates.HelsenorgeEncryptionThumbprint), _logger);
             var result = partyBProtection.Unprotect(
                 stream, 
                 TestCertificates.GetCertificate(TestCertificates.CounterpartySignatureThumbprint));
@@ -52,12 +56,13 @@ namespace Helsenorge.Messaging.Tests.Security
         {
             MemoryStream contentStream = new MemoryStream(Encoding.UTF8.GetBytes(_content.ToString()));
 
-            var partyAProtection = new SignThenEncryptMessageProtection(TestCertificates.GetCertificate(TestCertificates.CounterpartySignatureThumbprint), TestCertificates.GetCertificate(TestCertificates.CounterpartyEncryptionThumbprint));
+            var partyAProtection = new SignThenEncryptMessageProtection(TestCertificates.GetCertificate(TestCertificates.CounterpartySignatureThumbprint), TestCertificates.GetCertificate(TestCertificates.CounterpartyEncryptionThumbprint), _logger);
             var stream = partyAProtection.Protect(contentStream, TestCertificates.GetCertificate(TestCertificates.HelsenorgeLegacyEncryptionThumbprint));
 
             var partyBProtection = new SignThenEncryptMessageProtection(
                 TestCertificates.GetCertificate(TestCertificates.HelsenorgeSignatureThumbprint),
                 TestCertificates.GetCertificate(TestCertificates.HelsenorgeEncryptionThumbprint),
+                _logger,
                 TestCertificates.GetCertificate(TestCertificates.HelsenorgeLegacyEncryptionThumbprint));  // Legacy certificate
             var result = partyBProtection.Unprotect(stream, TestCertificates.GetCertificate(TestCertificates.CounterpartySignatureThumbprint));
 
@@ -73,10 +78,10 @@ namespace Helsenorge.Messaging.Tests.Security
             var wrongCertificate = new X509Certificate2(Convert.FromBase64String(wrongCertificateBase64));
             MemoryStream contentStream = new MemoryStream(Encoding.UTF8.GetBytes(_content.ToString()));
 
-            var partyAProtection = new SignThenEncryptMessageProtection(TestCertificates.GetCertificate(TestCertificates.CounterpartySignatureThumbprint), TestCertificates.GetCertificate(TestCertificates.CounterpartyEncryptionThumbprint));
+            var partyAProtection = new SignThenEncryptMessageProtection(TestCertificates.GetCertificate(TestCertificates.CounterpartySignatureThumbprint), TestCertificates.GetCertificate(TestCertificates.CounterpartyEncryptionThumbprint), _logger);
             var stream = partyAProtection.Protect(contentStream, TestCertificates.GetCertificate(TestCertificates.HelsenorgeEncryptionThumbprint));
             
-            var partyBProtection = new SignThenEncryptMessageProtection(TestCertificates.GetCertificate(TestCertificates.HelsenorgeSignatureThumbprint), TestCertificates.GetCertificate(TestCertificates.HelsenorgeEncryptionThumbprint));
+            var partyBProtection = new SignThenEncryptMessageProtection(TestCertificates.GetCertificate(TestCertificates.HelsenorgeSignatureThumbprint), TestCertificates.GetCertificate(TestCertificates.HelsenorgeEncryptionThumbprint), _logger);
             var result = partyBProtection.Unprotect(stream, wrongCertificate);
         }
 
@@ -87,11 +92,11 @@ namespace Helsenorge.Messaging.Tests.Security
         {
             MemoryStream contentStream = new MemoryStream(Encoding.UTF8.GetBytes(_content.ToString()));
 
-            var partyAProtection = new SignThenEncryptMessageProtection(TestCertificates.GetCertificate(TestCertificates.CounterpartySignatureThumbprint), TestCertificates.GetCertificate(TestCertificates.CounterpartyEncryptionThumbprint));
+            var partyAProtection = new SignThenEncryptMessageProtection(TestCertificates.GetCertificate(TestCertificates.CounterpartySignatureThumbprint), TestCertificates.GetCertificate(TestCertificates.CounterpartyEncryptionThumbprint), _logger);
             // Random encryption certificate -> TestCertificates.CounterpartyPublicEncryption
             var stream = partyAProtection.Protect(contentStream, TestCertificates.GetCertificate(TestCertificates.CounterpartyEncryptionThumbprint));
 
-            var partyBProtection = new SignThenEncryptMessageProtection(TestCertificates.GetCertificate(TestCertificates.HelsenorgeSignatureThumbprint), TestCertificates.GetCertificate(TestCertificates.HelsenorgeEncryptionThumbprint));
+            var partyBProtection = new SignThenEncryptMessageProtection(TestCertificates.GetCertificate(TestCertificates.HelsenorgeSignatureThumbprint), TestCertificates.GetCertificate(TestCertificates.HelsenorgeEncryptionThumbprint), _logger);
             var result = partyBProtection.Unprotect(stream, TestCertificates.GetCertificate(TestCertificates.CounterpartySignatureThumbprint));
         }
 
@@ -99,7 +104,7 @@ namespace Helsenorge.Messaging.Tests.Security
         [ExpectedException(typeof(ArgumentNullException))]
         public void Protect_Data_ArgumentNullException()
         {
-            var partyAProtection = new SignThenEncryptMessageProtection(TestCertificates.GetCertificate(TestCertificates.CounterpartySignatureThumbprint), TestCertificates.GetCertificate(TestCertificates.CounterpartyEncryptionThumbprint));
+            var partyAProtection = new SignThenEncryptMessageProtection(TestCertificates.GetCertificate(TestCertificates.CounterpartySignatureThumbprint), TestCertificates.GetCertificate(TestCertificates.CounterpartyEncryptionThumbprint), _logger);
             partyAProtection.Protect(null, TestCertificates.GetCertificate(TestCertificates.HelsenorgeEncryptionThumbprint));
         }
 
@@ -109,7 +114,7 @@ namespace Helsenorge.Messaging.Tests.Security
         {
             MemoryStream contentStream = new MemoryStream(Encoding.UTF8.GetBytes(_content.ToString()));
 
-            var partyAProtection = new SignThenEncryptMessageProtection(TestCertificates.GetCertificate(TestCertificates.CounterpartySignatureThumbprint), TestCertificates.GetCertificate(TestCertificates.CounterpartyEncryptionThumbprint));
+            var partyAProtection = new SignThenEncryptMessageProtection(TestCertificates.GetCertificate(TestCertificates.CounterpartySignatureThumbprint), TestCertificates.GetCertificate(TestCertificates.CounterpartyEncryptionThumbprint), _logger);
             partyAProtection.Protect(contentStream, null);
         }
 
@@ -117,7 +122,7 @@ namespace Helsenorge.Messaging.Tests.Security
         [ExpectedException(typeof(ArgumentNullException))]
         public void Protect_Signature_ArgumentNullException()
         {
-            new SignThenEncryptMessageProtection(null, TestCertificates.GetCertificate(TestCertificates.CounterpartyEncryptionThumbprint));
+            new SignThenEncryptMessageProtection(null, TestCertificates.GetCertificate(TestCertificates.CounterpartyEncryptionThumbprint), _logger);
         }
 
         [TestMethod]
@@ -125,7 +130,7 @@ namespace Helsenorge.Messaging.Tests.Security
         [TestCategory("X509Chain")]
         public void Unprotect_Data_ArgumentNullException()
         {
-            var partyBProtection = new SignThenEncryptMessageProtection(TestCertificates.GetCertificate(TestCertificates.CounterpartySignatureThumbprint), TestCertificates.GetCertificate(TestCertificates.CounterpartyEncryptionThumbprint));
+            var partyBProtection = new SignThenEncryptMessageProtection(TestCertificates.GetCertificate(TestCertificates.CounterpartySignatureThumbprint), TestCertificates.GetCertificate(TestCertificates.CounterpartyEncryptionThumbprint), _logger);
             partyBProtection.Unprotect(null, TestCertificates.GetCertificate(TestCertificates.CounterpartySignatureThumbprint));
         }
 
@@ -134,7 +139,7 @@ namespace Helsenorge.Messaging.Tests.Security
         [TestCategory("X509Chain")]
         public void Unprotect_Encryption_ArgumentNullException()
         {
-            new SignThenEncryptMessageProtection(TestCertificates.GetCertificate(TestCertificates.HelsenorgeSignatureThumbprint), null);
+            new SignThenEncryptMessageProtection(TestCertificates.GetCertificate(TestCertificates.HelsenorgeSignatureThumbprint), null, _logger);
         }
 
         [TestMethod]
@@ -143,10 +148,10 @@ namespace Helsenorge.Messaging.Tests.Security
         {
             MemoryStream contentStream = new MemoryStream(Encoding.UTF8.GetBytes(_content.ToString()));
 
-            var partyAProtection = new SignThenEncryptMessageProtection(TestCertificates.GetCertificate(TestCertificates.CounterpartySignatureThumbprint), TestCertificates.GetCertificate(TestCertificates.CounterpartyEncryptionThumbprint));
+            var partyAProtection = new SignThenEncryptMessageProtection(TestCertificates.GetCertificate(TestCertificates.CounterpartySignatureThumbprint), TestCertificates.GetCertificate(TestCertificates.CounterpartyEncryptionThumbprint), _logger);
             var stream = partyAProtection.Protect(contentStream, TestCertificates.GetCertificate(TestCertificates.HelsenorgeEncryptionThumbprint));
 
-            var partyBProtection = new SignThenEncryptMessageProtection(TestCertificates.GetCertificate(TestCertificates.HelsenorgeSignatureThumbprint), TestCertificates.GetCertificate(TestCertificates.HelsenorgeEncryptionThumbprint));
+            var partyBProtection = new SignThenEncryptMessageProtection(TestCertificates.GetCertificate(TestCertificates.HelsenorgeSignatureThumbprint), TestCertificates.GetCertificate(TestCertificates.HelsenorgeEncryptionThumbprint), _logger);
             var result = partyBProtection.Unprotect(stream, null);
 
             Assert.AreEqual(_content.ToString(), result.ToXDocument().ToString());


### PR DESCRIPTION
This is gonna be used for statistics on what encryption types are being used. Will also be used to name and shame software that is using encryption algorithms that are past the EoL