### PR TITLE
Meta+deps: Remove the netcoreapp3.1 target and bump various dependencies

### DIFF
--- a/Examples/Helsenorge.Messaging.Client/Helsenorge.Messaging.Client.csproj
+++ b/Examples/Helsenorge.Messaging.Client/Helsenorge.Messaging.Client.csproj
@@ -11,7 +11,7 @@
     <SignAssembly>false</SignAssembly>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="4.0.2" />
+    <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="4.1.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="6.0.0" />

--- a/Examples/Helsenorge.Messaging.Server/Helsenorge.Messaging.Server.csproj
+++ b/Examples/Helsenorge.Messaging.Server/Helsenorge.Messaging.Server.csproj
@@ -11,7 +11,7 @@
     <SignAssembly>false</SignAssembly>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="4.0.2" />
+    <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="4.1.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="6.0.0" />

--- a/src/Helsenorge.Registries/Helsenorge.Registries.csproj
+++ b/src/Helsenorge.Registries/Helsenorge.Registries.csproj
@@ -25,7 +25,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="3.1.32" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.32" />
   </ItemGroup>
 

--- a/test/Helsenorge.Messaging.AdminLib.Tests/Helsenorge.Messaging.AdminLib.Tests.csproj
+++ b/test/Helsenorge.Messaging.AdminLib.Tests/Helsenorge.Messaging.AdminLib.Tests.csproj
@@ -12,8 +12,8 @@
 
     <ItemGroup>
       <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
-      <PackageReference Include="xunit" Version="2.4.2" />
-      <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <PackageReference Include="xunit" Version="2.5.0" />
+      <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       </PackageReference>

--- a/test/Helsenorge.Messaging.AdminLib.Tests/Helsenorge.Messaging.AdminLib.Tests.csproj
+++ b/test/Helsenorge.Messaging.AdminLib.Tests/Helsenorge.Messaging.AdminLib.Tests.csproj
@@ -11,7 +11,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
+      <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
       <PackageReference Include="xunit" Version="2.4.2" />
       <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
         <PrivateAssets>all</PrivateAssets>

--- a/test/Helsenorge.Messaging.Tests/Helsenorge.Messaging.Tests.csproj
+++ b/test/Helsenorge.Messaging.Tests/Helsenorge.Messaging.Tests.csproj
@@ -16,7 +16,7 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
         <PackageReference Include="Moq" Version="4.20.69" />
-        <PackageReference Include="MSTest.TestAdapter" Version="3.0.4" />
+        <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
         <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
         <PackageReference Include="xunit" Version="2.4.2" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">

--- a/test/Helsenorge.Messaging.Tests/Helsenorge.Messaging.Tests.csproj
+++ b/test/Helsenorge.Messaging.Tests/Helsenorge.Messaging.Tests.csproj
@@ -18,8 +18,8 @@
         <PackageReference Include="Moq" Version="4.20.69" />
         <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
         <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
-        <PackageReference Include="xunit" Version="2.4.2" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+        <PackageReference Include="xunit" Version="2.5.0" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/test/Helsenorge.Messaging.Tests/Helsenorge.Messaging.Tests.csproj
+++ b/test/Helsenorge.Messaging.Tests/Helsenorge.Messaging.Tests.csproj
@@ -15,7 +15,7 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
-        <PackageReference Include="Moq" Version="4.18.4" />
+        <PackageReference Include="Moq" Version="4.20.69" />
         <PackageReference Include="MSTest.TestAdapter" Version="3.0.4" />
         <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
         <PackageReference Include="xunit" Version="2.4.2" />

--- a/test/Helsenorge.Messaging.Tests/Helsenorge.Messaging.Tests.csproj
+++ b/test/Helsenorge.Messaging.Tests/Helsenorge.Messaging.Tests.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
+        <TargetFramework>net6.0</TargetFramework>
         <LangVersion>10.0</LangVersion>
         <AssemblyName>Helsenorge.Messaging.Tests</AssemblyName>
         <RootNamespace>Helsenorge.Messaging.Tests</RootNamespace>

--- a/test/Helsenorge.Messaging.Tests/Helsenorge.Messaging.Tests.csproj
+++ b/test/Helsenorge.Messaging.Tests/Helsenorge.Messaging.Tests.csproj
@@ -14,7 +14,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
         <PackageReference Include="Moq" Version="4.20.69" />
         <PackageReference Include="MSTest.TestAdapter" Version="3.0.4" />
         <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />

--- a/test/Helsenorge.Registries.Tests/Helsenorge.Registries.Tests.csproj
+++ b/test/Helsenorge.Registries.Tests/Helsenorge.Registries.Tests.csproj
@@ -13,7 +13,7 @@
     </PropertyGroup>
     
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
         <PackageReference Include="MSTest.TestAdapter" Version="3.0.4" />
         <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
         <PackageReference Include="xunit" Version="2.4.2" />

--- a/test/Helsenorge.Registries.Tests/Helsenorge.Registries.Tests.csproj
+++ b/test/Helsenorge.Registries.Tests/Helsenorge.Registries.Tests.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
+        <TargetFramework>net6.0</TargetFramework>
         <AssemblyName>Helsenorge.Registries.Tests</AssemblyName>
         <RootNamespace>Helsenorge.Registries.Tests</RootNamespace>
         <ProjectGuid>{0DD35E31-7384-4F3D-BBE0-366993DC2307}</ProjectGuid>

--- a/test/Helsenorge.Registries.Tests/Helsenorge.Registries.Tests.csproj
+++ b/test/Helsenorge.Registries.Tests/Helsenorge.Registries.Tests.csproj
@@ -14,7 +14,7 @@
     
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
-        <PackageReference Include="MSTest.TestAdapter" Version="3.0.4" />
+        <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
         <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
         <PackageReference Include="xunit" Version="2.4.2" />
         <PackageReference Include="xunit.assert" Version="2.4.2" />

--- a/test/Helsenorge.Registries.Tests/Helsenorge.Registries.Tests.csproj
+++ b/test/Helsenorge.Registries.Tests/Helsenorge.Registries.Tests.csproj
@@ -16,9 +16,9 @@
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
         <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
         <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
-        <PackageReference Include="xunit" Version="2.4.2" />
-        <PackageReference Include="xunit.assert" Version="2.4.2" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+        <PackageReference Include="xunit" Version="2.5.0" />
+        <PackageReference Include="xunit.assert" Version="2.5.0" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>


### PR DESCRIPTION
.NET Core 3.1 target is EOL and can safely be removed. See individual commits for more details.