### PR TITLE
Tests: Remove our dependency on Moq

### DIFF
--- a/test/Helsenorge.Messaging.Tests/Helsenorge.Messaging.Tests.csproj
+++ b/test/Helsenorge.Messaging.Tests/Helsenorge.Messaging.Tests.csproj
@@ -15,7 +15,6 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
-        <PackageReference Include="Moq" Version="4.20.69" />
         <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
         <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
         <PackageReference Include="xunit" Version="2.5.0" />


### PR DESCRIPTION
We did no really use Moq for much, and we had our own Mocking Provider for creating loggers so let's use that one.