### PR TITLE
Registries: Clarify why we avoid locking when retrieving ChannelFactory

### DIFF
--- a/src/Helsenorge.Registries/Utilities/SoapServiceInvoker.cs
+++ b/src/Helsenorge.Registries/Utilities/SoapServiceInvoker.cs
@@ -129,17 +129,20 @@ namespace Helsenorge.Registries.Utilities
         [ExcludeFromCodeCoverage] // requires wire communication
         internal ChannelFactory<TContract> GetChannelFactory<TContract>()
         {
-            if (!FactoryCache.TryGetValue(typeof(TContract), out var factoryObject))
+            // First, try to retrieve ChannelFactory from cache without locking.
+            if (FactoryCache.TryGetValue(typeof(TContract), out var factoryObject))
+                return (ChannelFactory<TContract>)factoryObject;
+
+            // If a ChannelFactory was not found, then lock and try again.
+            lock (_lockerObject)
             {
-                lock (_lockerObject)
-                {
-                    if (!FactoryCache.TryGetValue(typeof(TContract), out factoryObject))
-                    {
-                        var factory = new ConfigurationChannelFactory<TContract>(_wcfConfiguration);
-                        FactoryCache.TryAdd(typeof(TContract), factory);
-                        factoryObject = factory;
-                    }
-                }
+                // Try to retrieve ChannelFactory from cache again, in case another thread already added it.
+                if (FactoryCache.TryGetValue(typeof(TContract), out factoryObject))
+                    return (ChannelFactory<TContract>)factoryObject;
+
+                var factory = new ConfigurationChannelFactory<TContract>(_wcfConfiguration);
+                FactoryCache.TryAdd(typeof(TContract), factory);
+                factoryObject = factory;
             }
             return (ChannelFactory<TContract>)factoryObject;
         }


### PR DESCRIPTION
This adds comments to clarify that we intentionally try to avoid locking the first time we try to retrieve the ChannelFactory from the cache, and also why we after locking try to retrieve the ChannelFactory again.

Also refactors the code a bit to avoid unnecessary indentation/nesting.