### PR TITLE
Extracting data from payload and adding them as amqp properties

### DIFF
--- a/src/Helsenorge.Messaging/Amqp/AmqpCore.cs
+++ b/src/Helsenorge.Messaging/Amqp/AmqpCore.cs
@@ -13,6 +13,7 @@ using System.Globalization;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
 using System.Threading.Tasks;
+using System.Xml.Linq;
 using Helsenorge.Messaging.Abstractions;
 using Helsenorge.Messaging.Amqp.Receivers;
 using Helsenorge.Registries;
@@ -232,6 +233,8 @@ namespace Helsenorge.Messaging.Amqp
             messagingMessage.ToHerId = outgoingMessage.ToHerId;
             messagingMessage.ApplicationTimestamp = DateTime.UtcNow;
 
+            ExtractAndAddMetaDataPropertiesIfEnabled(messagingMessage, outgoingMessage.Payload, logger);
+
             if(profile.CpaId != Guid.Empty)
             {
                 messagingMessage.CpaId = profile.CpaId.ToString("D");
@@ -241,6 +244,28 @@ namespace Helsenorge.Messaging.Amqp
 
             stopwatch.Stop();
             logger.LogEndSend(queueType, messagingMessage.MessageFunction, messagingMessage.FromHerId, messagingMessage.ToHerId, messagingMessage.MessageId, stopwatch.ElapsedMilliseconds);
+        }
+
+        private void ExtractAndAddMetaDataPropertiesIfEnabled(IAmqpMessage amqpMessage, XDocument payload, ILogger logger)
+        {
+            if (Core.Settings.SkipAddingPayloadMetadataIntoApplicationProperties) return;
+
+            try
+            {
+                var sw = Stopwatch.StartNew();
+                logger.LogInformation($"Before-AddingPayloadMetadata: {amqpMessage.MessageFunction} FromHerId: {amqpMessage.FromHerId} ToHerId: {amqpMessage.ToHerId}  MessageId: {amqpMessage.MessageId}");
+                var metaDataProperties = MetadataHelper.ExtractMessageProperties(payload) ?? new Dictionary<string, string>();
+                foreach (var metaDataProperty in metaDataProperties)
+                {
+                    amqpMessage.SetApplicationPropertyValue(metaDataProperty.Key, metaDataProperty.Value);
+                }
+                sw.Stop();
+                logger.LogInformation($"After-AddingPayloadMetadata: {amqpMessage.MessageFunction} FromHerId: {amqpMessage.FromHerId} ToHerId: {amqpMessage.ToHerId}  MessageId: {amqpMessage.MessageId} Elapsed:{sw.ElapsedMilliseconds}");
+            }
+            catch (Exception e)
+            {
+                logger.LogWarning(e, $"Exception when AddingPayloadMetadata: {amqpMessage.MessageFunction} FromHerId: {amqpMessage.FromHerId} ToHerId: {amqpMessage.ToHerId}  MessageId: {amqpMessage.MessageId}");
+            }
         }
 
         /// <summary>

--- a/src/Helsenorge.Messaging/Amqp/MetadataHelper.cs
+++ b/src/Helsenorge.Messaging/Amqp/MetadataHelper.cs
@@ -1,0 +1,232 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Xml;
+using System.Xml.Linq;
+using System.Xml.XPath;
+
+namespace Helsenorge.Messaging.Amqp;
+
+/// <summary>
+/// Helper class to extract insensitive data from xml business messages
+/// </summary>
+public static class MetadataHelper
+{
+    private static XmlNamespaceManager _manager;
+    private const string MsgHead = "http://www.kith.no/xmlstds/msghead/2006-05-24";
+    private const string Base64Container = "http://www.kith.no/xmlstds/base64container";
+    private const string Apprec10 = "http://www.kith.no/xmlstds/apprec/2004-11-21";
+    private const string Apprec11 = "http://www.kith.no/xmlstds/apprec/2012-02-15";
+
+    //prefixes
+    private const string MH = "mh";
+    private const string A10 = "a10";
+    private const string A11 = "a11";
+    private const string B = "b";
+
+    static MetadataHelper()
+    {
+        _manager = new XmlNamespaceManager(new NameTable());
+        _manager.AddNamespace(MH, MsgHead);
+        _manager.AddNamespace(A10, Apprec10);
+        _manager.AddNamespace(A11, Apprec11);
+        _manager.AddNamespace(B, Base64Container);
+    }
+
+    /// <summary>
+    /// Extracting properties from XML
+    /// Implemented support for:
+    ///  - MsgHead 1.2 - http://www.kith.no/xmlstds/msghead/2006-05-24
+    ///  - Apprec 1.0 - http://www.kith.no/xmlstds/apprec/2004-11-21
+    ///  - Apprec 1.1 - http://www.kith.no/xmlstds/apprec/2012-02-15
+    /// </summary>
+    /// <param name="payload"></param>
+    /// <returns></returns>
+    public static IDictionary<string, string> ExtractMessageProperties(XDocument payload)
+    {
+        var el = payload?.Root;
+        if (el == null) return new Dictionary<string, string>();
+
+        var defaultNamespace = el.GetDefaultNamespace()?.NamespaceName;
+        var properties = defaultNamespace switch
+        {
+            MsgHead => ExtractMessagePropertiesFromMsgHead(el),
+            Apprec10 => ExtractMessagePropertiesFromApprec(el, A10),
+            Apprec11 => ExtractMessagePropertiesFromApprec(el, A11),
+            _ => ExtractMessagePropertiesFromUnspecified(el)
+        };
+
+        return properties.ToDictionary(k=>k.Key, v=>v.Value);
+    }
+
+    private static IEnumerable<KeyValuePair<string, string>> ExtractMessagePropertiesFromUnspecified(XElement el)
+    {
+        var mainNs = el.GetDefaultNamespace()?.NamespaceName;
+        if (!string.IsNullOrWhiteSpace(mainNs))
+            yield return new KeyValuePair<string, string>(MetadataKeys.MessageInfoSchemaNamespace, mainNs);
+    }
+
+    private static IEnumerable<KeyValuePair<string, string>> ExtractMessagePropertiesFromApprec(XElement el,
+        string prefix)
+    {
+        var apprecEl = GetElement($"/{prefix}:AppRec", el);
+        var mainNs = apprecEl.GetDefaultNamespace()?.NamespaceName;
+        if (!string.IsNullOrWhiteSpace(mainNs))
+            yield return new KeyValuePair<string, string>(MetadataKeys.MessageInfoSchemaNamespace, mainNs);
+        var msgType = GetElementAttribute($"{prefix}:MsgType", "V", apprecEl)?.Value;
+        if (!string.IsNullOrWhiteSpace(msgType))
+            yield return new KeyValuePair<string, string>(MetadataKeys.MessageInfoMsgType, msgType);
+        var msgId = GetElement($"{prefix}:Id", apprecEl)?.Value;
+        if (!string.IsNullOrWhiteSpace(msgId))
+            yield return new KeyValuePair<string, string>(MetadataKeys.MessageInfoMsgId, msgId);
+
+        var originalEl = GetElement($"{prefix}:OriginalMsgId", apprecEl);
+        var originalMsgId = GetElement($"{prefix}:Id", originalEl)?.Value;
+        if (!string.IsNullOrWhiteSpace(originalMsgId))
+            yield return new KeyValuePair<string, string>(MetadataKeys.MessageInfoOriginalMsgId, originalMsgId);
+        var originalMsgType = GetElementAttribute($"{prefix}:MsgType", "V", originalEl)?.Value;
+        if (!string.IsNullOrWhiteSpace(originalMsgType))
+            yield return new KeyValuePair<string, string>(MetadataKeys.MessageInfoOriginalMsgType, originalMsgType);
+
+        var senderEl = GetElement($"{prefix}:Sender", apprecEl);
+        var senderLvl1Id = GetApprecLvl1Id(senderEl, prefix);
+        if (!string.IsNullOrWhiteSpace(senderLvl1Id))
+            yield return new KeyValuePair<string, string>(MetadataKeys.SenderLvl1Id, senderLvl1Id);
+        var senderLvl2Id = GetApprecLvl2Id(senderEl, prefix);
+        if (!string.IsNullOrWhiteSpace(senderLvl2Id))
+            yield return new KeyValuePair<string, string>(MetadataKeys.SenderLvl2Id, senderLvl2Id);
+
+        var receiverEl = GetElement($"{prefix}:Receiver", apprecEl);
+        var receiverLvl1Id = GetApprecLvl1Id(receiverEl, prefix);
+        if (!string.IsNullOrWhiteSpace(receiverLvl1Id))
+            yield return new KeyValuePair<string, string>(MetadataKeys.ReceiverLvl1Id, receiverLvl1Id);
+        var receiverLvl2Id = GetApprecLvl2Id(receiverEl, prefix);
+        if (!string.IsNullOrWhiteSpace(receiverLvl2Id))
+            yield return new KeyValuePair<string, string>(MetadataKeys.ReceiverLvl2Id, receiverLvl2Id);
+    }
+
+    private static IEnumerable<KeyValuePair<string, string>> ExtractMessagePropertiesFromMsgHead(XElement el)
+    {
+        var msgInfoEl = GetElement($"//{MH}:MsgInfo", el);
+        var msgInfoType = GetElementAttribute($"{MH}:Type", "V", msgInfoEl)?.Value;
+        if (!string.IsNullOrWhiteSpace(msgInfoType))
+            yield return new KeyValuePair<string, string>(MetadataKeys.MessageInfoMsgType, msgInfoType);
+
+        var msgInfoMsgId = GetElement($"{MH}:MsgId", msgInfoEl)?.Value;
+        if (!string.IsNullOrWhiteSpace(msgInfoMsgId))
+            yield return new KeyValuePair<string, string>(MetadataKeys.MessageInfoMsgId, msgInfoMsgId);
+
+        var conversationRefEl = GetElement($"{MH}:ConversationRef", msgInfoEl);
+        var msgInfoRefToParent = GetElement($"{MH}:RefToParent", conversationRefEl)?.Value;
+        if (!string.IsNullOrWhiteSpace(msgInfoRefToParent))
+            yield return new KeyValuePair<string, string>(MetadataKeys.MessageInfoRefToParent, msgInfoRefToParent);
+
+        var msgInfoRefToConversation = GetElement($"{MH}:RefToConversation", conversationRefEl)?.Value;
+        if (!string.IsNullOrWhiteSpace(msgInfoRefToConversation))
+            yield return new KeyValuePair<string, string>(MetadataKeys.MessageInfoRefConversation,
+                msgInfoRefToConversation);
+
+        var senderEl = GetElement($"{MH}:Sender", msgInfoEl);
+        var senderLvl1Id = GetMsgHeadLvl1Id(senderEl);
+        if (!string.IsNullOrWhiteSpace(senderLvl1Id))
+            yield return new KeyValuePair<string, string>(MetadataKeys.SenderLvl1Id, senderLvl1Id);
+        var senderLvl2Id = GetMsgHeadLvl2Id(senderEl);
+        if (!string.IsNullOrWhiteSpace(senderLvl2Id))
+            yield return new KeyValuePair<string, string>(MetadataKeys.SenderLvl2Id, senderLvl2Id);
+
+        var receiverEl = GetElement($"{MH}:Receiver", msgInfoEl);
+        var receiverLvl1Id = GetMsgHeadLvl1Id(receiverEl);
+        if (!string.IsNullOrWhiteSpace(receiverLvl1Id))
+            yield return new KeyValuePair<string, string>(MetadataKeys.ReceiverLvl1Id, receiverLvl1Id);
+        var receiverLvl2Id = GetMsgHeadLvl2Id(receiverEl);
+        if (!string.IsNullOrWhiteSpace(receiverLvl2Id))
+            yield return new KeyValuePair<string, string>(MetadataKeys.ReceiverLvl2Id, receiverLvl2Id);
+
+        var documents = GetElements($"//{MH}:Document", el);
+        var attachmentCounter = 0;
+        int attachmentsTotalCount = 0;
+        var hasExternalReference = false;
+        for (int i = 0; i < documents.Count(); i++)
+        {
+            var currentDocument = documents.ElementAt(i);
+            if (i == 0)
+            {
+                var innerDocument = GetElement($"{MH}:RefDoc/{MH}:Content", currentDocument)?.FirstNode as XElement;
+                var innerNamespace = innerDocument?.GetDefaultNamespace()?.NamespaceName;
+                if (!string.IsNullOrWhiteSpace(innerNamespace))
+                    yield return new KeyValuePair<string, string>(MetadataKeys.MessageInfoSchemaNamespace,
+                        innerNamespace);
+            }
+            else
+            {
+                attachmentCounter++;
+                var basee64ContentEl = GetElement($"{MH}:RefDoc/{MH}:Content/{B}:Base64Container", currentDocument);
+                if (basee64ContentEl != null)
+                {
+                    var contentString = basee64ContentEl.Value;
+                    var bytes = Encoding.UTF8.GetBytes(contentString);
+                    if (bytes.Length > 0) attachmentsTotalCount += bytes.Length;
+                }
+
+                var fileReferenceContent = GetElement($"{MH}:RefDoc/{MH}:FileReference", currentDocument);
+                if (fileReferenceContent != null) hasExternalReference = true;
+            }
+        }
+
+        yield return new KeyValuePair<string, string>(MetadataKeys.AttachmentInfoCount, attachmentCounter.ToString());
+        yield return new KeyValuePair<string, string>(MetadataKeys.AttachmentInfoTotalSizeInBytes,
+            attachmentsTotalCount.ToString());
+        yield return new KeyValuePair<string, string>(MetadataKeys.AttachmentInfoHasExternalReference,
+            hasExternalReference.ToString());
+    }
+
+    private static string GetApprecLvl1Id(XElement senderReceiverElement, string prefix)
+    {
+        var idents = GetElements($"{prefix}:HCP/{prefix}:Inst/{prefix}:TypeId", senderReceiverElement);
+        var identOfInterest = idents.FirstOrDefault(se => se.Attribute("V")?.Value == "HER");
+        return GetElement($"{prefix}:Id", identOfInterest?.Parent)?.Value;
+    }
+
+    private static string GetApprecLvl2Id(XElement senderReceiverElement, string prefix)
+    {
+        var identsOrg = GetElements($"{prefix}:HCP/{prefix}:Inst/{prefix}:Dept/{prefix}:TypeId", senderReceiverElement);
+        var identsHcp = GetElements($"{prefix}:HCP/{prefix}:Inst/{prefix}:HCPerson/{prefix}:TypeId",
+            senderReceiverElement);
+        var allIdents = identsOrg.Union(identsHcp);
+        var identOfInterest = allIdents.FirstOrDefault(se => se.Attribute("V")?.Value == "HER");
+        return GetElement($"{prefix}:Id", identOfInterest?.Parent)?.Value;
+    }
+
+    private static string GetMsgHeadLvl1Id(XElement senderReceiverElement)
+    {
+        var idents = GetElements($"{MH}:Organisation/{MH}:Ident/{MH}:TypeId", senderReceiverElement);
+        var identOfInterest = idents.FirstOrDefault(se => se.Attribute("V")?.Value == "HER");
+        return GetElement($"{MH}:Id", identOfInterest?.Parent)?.Value;
+    }
+
+    private static string GetMsgHeadLvl2Id(XElement senderReceiverElement)
+    {
+        var identsOrg = GetElements($"{MH}:Organisation/{MH}:Organisation/{MH}:Ident/{MH}:TypeId",
+            senderReceiverElement);
+        var identsHcp = GetElements($"{MH}:Organisation/{MH}:HealthcareProfessional/{MH}:Ident/{MH}:TypeId",
+            senderReceiverElement);
+        var allIdents = identsOrg.Union(identsHcp);
+        var identOfInterest = allIdents.FirstOrDefault(se => se.Attribute("V")?.Value == "HER");
+        return GetElement($"{MH}:Id", identOfInterest?.Parent)?.Value;
+    }
+
+    private static XElement GetElement(string expression, XElement el)
+    {
+        return el?.XPathSelectElement(expression, _manager);
+    }
+
+    private static IEnumerable<XElement> GetElements(string expression, XElement el)
+    {
+        return el?.XPathSelectElements(expression, _manager);
+    }
+
+    private static XAttribute GetElementAttribute(string expression, string attribute, XElement el)
+    {
+        return GetElement(expression, el)?.Attribute(attribute);
+    }
+}

--- a/src/Helsenorge.Messaging/Amqp/MetadataKeys.cs
+++ b/src/Helsenorge.Messaging/Amqp/MetadataKeys.cs
@@ -1,5 +1,8 @@
 ﻿namespace Helsenorge.Messaging.Amqp;
 
+/// <summary>
+/// Keys or Identifiers for the various metadata properties extracted from xml payload
+/// </summary>
 public static class MetadataKeys
 {
     /// <summary>

--- a/src/Helsenorge.Messaging/Amqp/MetadataKeys.cs
+++ b/src/Helsenorge.Messaging/Amqp/MetadataKeys.cs
@@ -1,0 +1,63 @@
+﻿namespace Helsenorge.Messaging.Amqp;
+
+public static class MetadataKeys
+{
+    /// <summary>
+    /// Identifier/Key used when adding MsgType from MsgHead into f.ex a Dictionary
+    /// </summary>
+    public const string MessageInfoMsgType = "X-MessageInfo-Type";
+    /// <summary>
+    /// Identifier/Key used when adding MsgId from MsgHead into f.ex a Dictionary
+    /// </summary>
+    public const string MessageInfoMsgId = "X-MessageInfo-MsgId";
+    /// <summary>
+    /// Identifier/Key used when adding RefToParent from MsgHead into f.ex a Dictionary
+    /// </summary>
+    public const string MessageInfoRefToParent = "X-MessageInfo-RefToParent";
+    /// <summary>
+    /// Identifier/Key used when adding RefToConversation from MsgHead into f.ex a Dictionary
+    /// </summary>
+    public const string MessageInfoRefConversation = "X-MessageInfo-RefToConversation";
+    /// <summary>
+    /// Identifier/Key used when adding SchemaNamespace from a payload into f.ex a Dictionary
+    /// </summary>
+    public const string MessageInfoSchemaNamespace = "X-MessageInfo-SchemaNamespace";
+    /// <summary>
+    /// Identifier/Key used when adding OriginalMsgId from an Apprec into f.ex a Dictionary
+    /// </summary>
+    public const string MessageInfoOriginalMsgId = "X-MessageInfo-OriginalMsgId";
+    /// <summary>
+    /// Identifier/Key used when adding OriginalMsgType from an Apprec into f.ex a Dictionary
+    /// </summary>
+    public const string MessageInfoOriginalMsgType = "X-MessageInfo-OriginalMsgType";
+
+    /// <summary>
+    /// Identifier/Key used when adding level 1 sender identifier/herid from a payload into f.ex a Dictionary
+    /// </summary>
+    public const string SenderLvl1Id = "X-Sender-Lvl1Id";
+    /// <summary>
+    /// Identifier/Key used when adding level 2 sender identifier/herid from a payload into f.ex a Dictionary
+    /// </summary>
+    public const string SenderLvl2Id = "X-Sender-Lvl2Id";
+    /// <summary>
+    /// Identifier/Key used when adding level 1 receiver identifier/herid from a payload into f.ex a Dictionary
+    /// </summary>
+    public const string ReceiverLvl1Id = "X-Receiver-Lvl1Id";
+    /// <summary>
+    /// Identifier/Key used when adding level 2 receiver identifier/herid from a payload into f.ex a Dictionary
+    /// </summary>
+    public const string ReceiverLvl2Id = "X-Receiver-Lvl2Id";
+
+    /// <summary>
+    /// Identifier/Key used when adding the number of attachments in a payload into f.ex a Dictionary
+    /// </summary>
+    public const string AttachmentInfoCount = "X-AttachmentInfo-Count";
+    /// <summary>
+    /// Identifier/Key used when adding the total size of all attachments in a payload into f.ex a Dictionary
+    /// </summary>
+    public const string AttachmentInfoTotalSizeInBytes = "X-AttachmentInfo-TotalSizeInBytes";
+    /// <summary>
+    /// Identifier/Key used when adding info if FileReference in MsgHead is used into f.ex a Dictionary
+    /// </summary>
+    public const string AttachmentInfoHasExternalReference = "X-AttachmentInfo-HasExternalReference";
+}

--- a/src/Helsenorge.Messaging/MessagingSettings.cs
+++ b/src/Helsenorge.Messaging/MessagingSettings.cs
@@ -59,6 +59,11 @@ namespace Helsenorge.Messaging
         public IDictionary<string, object> ApplicationProperties { get; } = new Dictionary<string, object>();
 
         /// <summary>
+        /// Indicates if we should NOT add metadata from payload into application properties. default: true
+        /// </summary>
+        public bool SkipAddingPayloadMetadataIntoApplicationProperties  { get; set; }
+
+        /// <summary>
         /// Skip CPA lookup for message functions in this list. Instead use an internal dummy CPA.
         /// </summary>
         public List<string> MessageFunctionsExcludedFromCpaResolve { get; set; } = new List<string>();

--- a/test/Helsenorge.Messaging.Tests/Amqp/MetadataHelperTests.cs
+++ b/test/Helsenorge.Messaging.Tests/Amqp/MetadataHelperTests.cs
@@ -1,0 +1,91 @@
+/* 
+ * Copyright (c) 2020-2023, Norsk Helsenett SF and contributors
+ * See the file CONTRIBUTORS for details.
+ * 
+ * This file is licensed under the MIT license
+ * available at https://raw.githubusercontent.com/helsenorge/Helsenorge.Messaging/master/LICENSE
+ */
+
+using System.Xml.Linq;
+using Helsenorge.Messaging.Amqp;
+using Xunit;
+
+namespace Helsenorge.Messaging.Tests.Amqp;
+
+public class MetadataHelperTests
+{
+    [Fact]
+    public void WhenPayloadIsMissing_ThenResponseShouldBeEmpty()
+    {
+        XDocument payload = null;
+        var properties = MetadataHelper.ExtractMessageProperties(payload);
+        Assert.Empty(properties);
+    }
+
+    [Fact]
+    public void WhenDialogmeldingIsValid_ThenAppPropsShouldBeAdded()
+    {
+        var payload = XDocument.Load($"Files/MetadataTestsDialogmelding11.xml");
+        var properties = MetadataHelper.ExtractMessageProperties(payload);
+        Assert.NotNull(properties);
+        Assert.NotEmpty(properties);
+
+        Assert.Equal("DIALOG_HELSEFAGLIG", properties[MetadataKeys.MessageInfoMsgType]);
+        Assert.Equal("de1a95c0-4d0c-11e7-9598-0800200c9a66", properties[MetadataKeys.MessageInfoMsgId]);
+        Assert.Equal("d14ea2f3-d796-4d7b-8271-a4480d2b4035", properties[MetadataKeys.MessageInfoRefToParent]);
+        Assert.Equal("a14ea2f3-d796-4d7b-8271-a4480d2b4037", properties[MetadataKeys.MessageInfoRefConversation]);
+
+        Assert.Equal("http://www.kith.no/xmlstds/dialog/2013-01-23", properties[MetadataKeys.MessageInfoSchemaNamespace]);
+
+        Assert.Equal("3", properties[MetadataKeys.AttachmentInfoCount]);
+        Assert.Equal("218", properties[MetadataKeys.AttachmentInfoTotalSizeInBytes]);
+        Assert.Equal("True", properties[MetadataKeys.AttachmentInfoHasExternalReference]);
+
+        Assert.Equal("56704", properties[MetadataKeys.SenderLvl1Id]);
+        Assert.Equal("258521", properties[MetadataKeys.SenderLvl2Id]);
+        Assert.Equal("59", properties[MetadataKeys.ReceiverLvl1Id]);
+        Assert.Equal("90998", properties[MetadataKeys.ReceiverLvl2Id]);
+    }
+
+    [Fact]
+    public void WhenApprec10gIsValid_ThenAllPropsShouldBeAdded()
+    {
+        var payload = XDocument.Load("Files/MetadataTests_Apprec10.xml");
+        var properties = MetadataHelper.ExtractMessageProperties(payload);
+        Assert.NotNull(properties);
+        Assert.NotEmpty(properties);
+
+        Assert.Equal("APPREC", properties[MetadataKeys.MessageInfoMsgType]);
+        Assert.Equal("A76D8934-D4BA-4A22-8F5D-5DF5E3FC5756", properties[MetadataKeys.MessageInfoMsgId]);
+        Assert.Equal("de1a95c0-4d0c-11e7-9598-0800200c9a66", properties[MetadataKeys.MessageInfoOriginalMsgId]);
+        Assert.Equal("DIALOG_HELSEFAGLIG", properties[MetadataKeys.MessageInfoOriginalMsgType]);
+        Assert.Equal("http://www.kith.no/xmlstds/apprec/2004-11-21", properties[MetadataKeys.MessageInfoSchemaNamespace]);
+
+        Assert.Equal("59", properties[MetadataKeys.SenderLvl1Id]);
+        Assert.Equal("90998", properties[MetadataKeys.SenderLvl2Id]);
+        Assert.Equal("56704", properties[MetadataKeys.ReceiverLvl1Id]);
+        Assert.Equal("258521", properties[MetadataKeys.ReceiverLvl2Id]);
+    }
+
+    [Fact]
+    public void WhenApprec11gIsValid_ThenAllPropsShouldBeAdded()
+    {
+        var payload = XDocument.Load("Files/MetadataTests_Apprec11.xml");
+        var properties = MetadataHelper.ExtractMessageProperties(payload);
+        Assert.NotNull(properties);
+        Assert.NotEmpty(properties);
+
+        Assert.Equal("APPREC", properties[MetadataKeys.MessageInfoMsgType]);
+        Assert.Equal("C829A5F9-5BBF-4376-A37F-ADE4B399916C", properties[MetadataKeys.MessageInfoMsgId]);
+        Assert.Equal("de1a95c0-4d0c-11e7-9598-0800200c9a66", properties[MetadataKeys.MessageInfoOriginalMsgId]);
+        Assert.Equal("DIALOG_HELSEFAGLIG", properties[MetadataKeys.MessageInfoOriginalMsgType]);
+        Assert.Equal("http://www.kith.no/xmlstds/apprec/2012-02-15", properties[MetadataKeys.MessageInfoSchemaNamespace]);
+
+        Assert.Equal("56704", properties[MetadataKeys.SenderLvl1Id]);
+        Assert.Equal("258521", properties[MetadataKeys.SenderLvl2Id]);
+        Assert.Equal("59", properties[MetadataKeys.ReceiverLvl1Id]);
+        Assert.Equal("90998", properties[MetadataKeys.ReceiverLvl2Id]);
+    }
+}
+
+

--- a/test/Helsenorge.Messaging.Tests/Amqp/Senders/AsynchronousSendTests.cs
+++ b/test/Helsenorge.Messaging.Tests/Amqp/Senders/AsynchronousSendTests.cs
@@ -178,5 +178,21 @@ namespace Helsenorge.Messaging.Tests.Amqp.Senders
             }
             
         }
+
+        [DataRow(2, null)]
+        [DataRow(2, false)]
+        [DataRow(0, true)]
+        [TestMethod]
+        public void Send_AsyncMessage_SkipAddingPayloadMetadata(int expectedLogElements, bool? configValue)
+        {
+            var message = CreateMessage();
+            if (configValue.HasValue)
+            {
+                Settings.SkipAddingPayloadMetadataIntoApplicationProperties = configValue.Value;
+            }
+            RunAndHandleException(Client.SendAndContinueAsync(message));
+
+            Assert.AreEqual(expectedLogElements, MockLoggerProvider.Entries.Count(x=>x.Message.Contains("AddingPayloadMetadata")));
+        }
     }
 }

--- a/test/Helsenorge.Messaging.Tests/Files/MetadataTestsDialogmelding11.xml
+++ b/test/Helsenorge.Messaging.Tests/Files/MetadataTestsDialogmelding11.xml
@@ -1,0 +1,130 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<!-- Eksempel på helsefaglig dialog ettersending av informasjon vedrørende henvisning -->
+<MsgHead xmlns="http://www.kith.no/xmlstds/msghead/2006-05-24" xmlns:xsd="http://www.w3.org/2001/XMLSchema.xsd" xmlns:fk1="http://www.kith.no/xmlstds/felleskomponent1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.kith.no/xmlstds/msghead/2006-05-24 MsgHead-v1_2.xsd">
+	<MsgInfo>
+		<Type V="DIALOG_HELSEFAGLIG" DN="Helsefaglig dialog"/>
+		<MIGversion>v1.2 2006-05-24</MIGversion>
+		<GenDate>2017-06-12T09:35:22</GenDate>
+		<MsgId>de1a95c0-4d0c-11e7-9598-0800200c9a66</MsgId>
+		<ConversationRef>
+			<RefToParent>d14ea2f3-d796-4d7b-8271-a4480d2b4035</RefToParent>
+			<RefToConversation>a14ea2f3-d796-4d7b-8271-a4480d2b4037</RefToConversation>
+		</ConversationRef>
+		<Sender>
+			<Organisation>
+				<OrganisationName>Kattskinnet legesenter</OrganisationName>
+				<Ident>
+					<Id>9999</Id>
+					<TypeId V="HPR" DN="Hpr nummer"/>
+				</Ident>				
+				<Ident>
+					<Id>56704</Id>
+					<TypeId V="HER" DN="HER-id" S="2.16.578.1.12.4.1.1.9051"/>
+				</Ident>	
+				<HealthcareProfessional>
+					<RoleToPatient DN="Fastlege" V="6" S="2.16.578.1.12.4.1.1.9034"/>
+					<FamilyName>Lin</FamilyName>
+					<GivenName>Rita</GivenName>
+					<Ident>
+						<Id>258521</Id>
+						<TypeId DN="HER-id" V="HER" S="2.16.578.1.12.4.1.1.9051"/>
+					</Ident>
+				</HealthcareProfessional>
+			</Organisation>
+		</Sender>
+		<Receiver>
+			<Organisation>
+				<OrganisationName>ST OLAVS HOSPITAL HF</OrganisationName>
+				<Ident>
+					<Id>59</Id>
+					<TypeId V="HER" DN="HER-id" S="2.16.578.1.12.4.1.1.9051"/>
+				</Ident>
+				<Organisation>
+					<OrganisationName>Ortopedisk kirurgi</OrganisationName>
+					<Ident>
+						<Id>90998</Id>
+						<TypeId V="HER" DN="HER-id" S="2.16.578.1.12.4.1.1.9051"/>
+					</Ident>
+				</Organisation>
+			</Organisation>
+		</Receiver>
+		<Patient>
+			<FamilyName>Danser</FamilyName>
+			<GivenName>Line</GivenName>
+			<Ident>
+				<Id>13116900216</Id>
+				<TypeId V="FNR" DN="Fødselsnummer" S="2.16.578.1.12.4.1.1.8116"/>
+			</Ident>
+		</Patient>
+	</MsgInfo>
+	<Document>
+		<RefDoc>
+			<IssueDate V="2017-06-12T09:23:47"/>
+			<MsgType V="XML" DN="XML-instans"/>
+			<Content>
+				<Dialogmelding xmlns="http://www.kith.no/xmlstds/dialog/2013-01-23" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.kith.no/xmlstds/dialog/2013-01-23 dialogmelding-v1.1.xsd">
+					<Notat>
+						<TemaKodet V="6" DN="Henvendelse om pasient" S="2.16.578.1.12.4.1.1.7322"/>
+						<Tema>EKG tatt i dag</Tema>
+						<TekstNotatInnhold>Pasienten er henvist til
+							kardiologisk poliklinikk for utredning med spørsmål om cardial årsak og mulig angina pectoris.
+							Ettersender EKG tatt i dag uten funn. Se vedlegg.						</TekstNotatInnhold>
+						<RollerRelatertNotat>
+							<RoleToPatient DN="Fastlege" V="6" S="2.16.578.1.12.4.1.1.9034"/>
+							<HealthcareProfessional>
+								<FamilyName>Lin</FamilyName>
+								<GivenName>Rita</GivenName>
+								<Ident>
+									<fk1:Id>258521</fk1:Id>
+									<fk1:TypeId V="HPR" DN="HPR-nummer" S="2.16.578.1.12.4.1.1.8116"/>
+								</Ident>
+								<TeleCom>
+									<fk1:TeleAddress V="tel:12345678"/>
+								</TeleCom>
+							</HealthcareProfessional>
+						</RollerRelatertNotat>
+					</Notat>
+				</Dialogmelding>
+			</Content>
+		</RefDoc>
+	</Document>
+	<Document>
+		<RefDoc>
+			<IssueDate V="2017-06-12T08:45:11"/>
+			<MsgType V="A" DN="Vedlegg"/>
+			<MimeType>application/pdf</MimeType>
+			<Description>EKG-2017-06-12</Description>
+			<Content>
+				<Base64Container xsi:schemaLocation="http://www.kith.no/xmlstds/base64container kith-base64.xsd" xmlns="http://www.kith.no/xmlstds/base64container" xmlns:xsi="http://www.w3.org/2001/XMLSchemainstance">
+					<!-- Inkludert vedlegg -->
+					TG90c2FuZExvdHNPZkF0dGFjaG1lbnRUZXh0w4bDmMOF
+				</Base64Container>
+			</Content>
+		</RefDoc>
+	</Document>
+	<Document>
+		<RefDoc>
+			<IssueDate V="2017-06-12T10:45:11"/>
+			<MsgType V="A" DN="Vedlegg"/>
+			<MimeType>application/pdf</MimeType>
+			<Description>EKG-2017-06-12</Description>
+			<FileReference>https://someurl.com/myfile.pdf</FileReference>
+		</RefDoc>
+	</Document>
+	<Document>
+		<RefDoc>
+			<IssueDate V="2017-06-12T08:45:11"/>
+			<MsgType V="A" DN="Vedlegg"/>
+			<MimeType>application/pdf</MimeType>
+			<Description>EKG-2017-06-12</Description>
+			<Content>
+				<Base64Container xsi:schemaLocation="http://www.kith.no/xmlstds/base64container kith-base64.xsd" xmlns="http://www.kith.no/xmlstds/base64container" xmlns:xsi="http://www.w3.org/2001/XMLSchemainstance">
+					<!-- Inkludert vedlegg -->
+					TG90c2FuZExvdHNPZkF0dGFjaG1lbnRUZXh0w4bDmMOFDQpMb3RzYW5kTG90c09m
+					QXR0YWNobWVudFRleHTDhsOYw4UNCkxvdHNhbmRMb3RzT2ZBdHRhY2htZW50VGV4
+					dMOGw5jDhQ==
+				</Base64Container>
+			</Content>
+		</RefDoc>
+	</Document>
+</MsgHead>

--- a/test/Helsenorge.Messaging.Tests/Files/MetadataTests_Apprec10.xml
+++ b/test/Helsenorge.Messaging.Tests/Files/MetadataTests_Apprec10.xml
@@ -1,0 +1,42 @@
+<AppRec xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns="http://www.kith.no/xmlstds/apprec/2004-11-21">
+    <MsgType V="APPREC" />
+    <MIGversion>1.0 2004-11-21</MIGversion>
+    <GenDate>2020-09-16T12:52:17.0009763Z</GenDate>
+    <Id>A76D8934-D4BA-4A22-8F5D-5DF5E3FC5756</Id>
+    <Sender>
+        <Role V="REQ" />
+        <HCP>
+            <Inst>
+                <Name>ST OLAVS HOSPITAL HF</Name>
+                <Id>59</Id>
+                <TypeId V="HER" DN="HER-id" />
+                <Dept>
+                    <Name>Ortopedisk kirurgi</Name>
+                    <Id>90998</Id>
+                    <TypeId V="HER" DN="HER-id" />
+                </Dept>
+            </Inst>
+        </HCP>
+    </Sender>
+    <Receiver>
+        <Role V="RECEIVER" />
+        <HCP>
+            <Inst>
+                <Name>Kattskinnet legesenter</Name>
+                <Id>56704</Id>
+                <TypeId V="HER" DN="HER-id" />
+                <Dept>
+                    <Name>Rita Lin</Name>
+                    <Id>258521</Id>
+                    <TypeId V="HER" DN="HER-id" />
+                </Dept>
+            </Inst>
+        </HCP>
+    </Receiver>
+    <Status V="1" DN="OK" />
+    <OriginalMsgId>
+        <MsgType V="DIALOG_HELSEFAGLIG" DN="Helsefaglig dialog" />
+        <IssueDate>2017-06-12T09:35:22</IssueDate>
+        <Id>de1a95c0-4d0c-11e7-9598-0800200c9a66</Id>
+    </OriginalMsgId>
+</AppRec>

--- a/test/Helsenorge.Messaging.Tests/Files/MetadataTests_Apprec11.xml
+++ b/test/Helsenorge.Messaging.Tests/Files/MetadataTests_Apprec11.xml
@@ -1,0 +1,42 @@
+<AppRec xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns="http://www.kith.no/xmlstds/apprec/2012-02-15">
+    <MsgType V="APPREC" />
+    <MIGversion>v1.1 2012-02-15</MIGversion>
+    <GenDate>2020-09-14T14:01:45.0004673Z</GenDate>
+    <Id>C829A5F9-5BBF-4376-A37F-ADE4B399916C</Id>
+    <Sender>
+        <Role V="PRIM" DN="Primærmottaker" />
+        <HCP>
+            <Inst>
+                <Name>>Kattskinnet legesenter</Name>
+                <Id>56704</Id>
+                <TypeId V="HER" DN="HER-id" />                
+                <HCPerson>
+                    <Name>Rita Lin</Name>
+                    <Id>258521</Id>
+                    <TypeId V="HER" DN="HER-id"/>
+                </HCPerson>
+            </Inst>
+        </HCP>
+    </Sender>
+    <Receiver>
+        <Role V="AVS" />
+        <HCP>
+            <Inst>
+                <Name>ST OLAVS HOSPITAL HF</Name>
+                <Id>59</Id>
+                <TypeId V="HER" DN="HER-id" />
+                <Dept>
+                    <Name>Ortopedisk kirurgi</Name>
+                    <Id>90998</Id>
+                    <TypeId V="HER" DN="HER-id" />
+                </Dept>
+            </Inst>
+        </HCP>
+    </Receiver>
+    <Status V="1" DN="OK" />
+    <OriginalMsgId>
+        <MsgType V="DIALOG_HELSEFAGLIG" DN="Helsefaglig dialog" />
+        <IssueDate>2017-06-12T09:35:22</IssueDate>
+        <Id>de1a95c0-4d0c-11e7-9598-0800200c9a66</Id>
+    </OriginalMsgId>
+</AppRec>

--- a/test/Helsenorge.Messaging.Tests/Helsenorge.Messaging.Tests.csproj
+++ b/test/Helsenorge.Messaging.Tests/Helsenorge.Messaging.Tests.csproj
@@ -29,4 +29,16 @@
         <ProjectReference Include="..\..\src\Helsenorge.Messaging\Helsenorge.Messaging.csproj" />
         <ProjectReference Include="..\Helsenorge.Registries.Tests\Helsenorge.Registries.Tests.csproj" />
     </ItemGroup>
+
+    <ItemGroup>
+      <None Update="Files\MetadataTests_Apprec10.xml">
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      </None>
+      <None Update="Files\MetadataTests_Apprec11.xml">
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      </None>
+      <None Update="Files\MetadataTestsDialogmelding11.xml">
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      </None>
+    </ItemGroup>
 </Project>

--- a/test/Helsenorge.Messaging.Tests/Helsenorge.Messaging.Tests.csproj
+++ b/test/Helsenorge.Messaging.Tests/Helsenorge.Messaging.Tests.csproj
@@ -31,14 +31,8 @@
     </ItemGroup>
 
     <ItemGroup>
-      <None Update="Files\MetadataTests_Apprec10.xml">
-        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      </None>
-      <None Update="Files\MetadataTests_Apprec11.xml">
-        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      </None>
-      <None Update="Files\MetadataTestsDialogmelding11.xml">
-        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      </None>
+        <None Update="Files\*.xml">
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory> 
+        </None>
     </ItemGroup>
 </Project>


### PR DESCRIPTION
Feature added to improve auditing and tracing
Important none-sensitive properties are extracted from the payload and added as amqp application properties.
This makes tracing MessageIds alot easier and also open for correlation between businessdocument and application receipt