### PR TITLE
Do not throw exception if XElement is null/empty

### DIFF
--- a/src/Helsenorge.Messaging/Amqp/MetadataHelper.cs
+++ b/src/Helsenorge.Messaging/Amqp/MetadataHelper.cs
@@ -105,8 +105,8 @@ public static class MetadataHelper
 
     private static string GetNamespace(XElement element)
     {
-        var ns =  element.GetDefaultNamespace()?.NamespaceName;
-        if (string.IsNullOrWhiteSpace(ns)) ns = element?.Name.NamespaceName;
+        var ns =  element?.GetDefaultNamespace()?.NamespaceName;
+        if (string.IsNullOrWhiteSpace(ns)) ns = element?.Name?.NamespaceName;
         return ns;
     }
 


### PR DESCRIPTION
If element is null it is a bug in the business logic calling this module but validating it is not part of this code's responsiblity