### PR TITLE
workflows: Add MacOS M1 Runner

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ${{ matrix.platform }}
     strategy:
       matrix:
-        platform: [ windows-latest, ubuntu-latest ]
+        platform: [ windows-latest, ubuntu-latest, macos-14 ]
     steps:
     - uses: actions/checkout@v4
     - name: Setup .NET Core 6.0


### PR DESCRIPTION
https://github.blog/changelog/2024-01-30-github-actions-introducing-the-new-m1-macos-runner-available-to-open-source/