### PR TITLE
Messaging: Add net9.0 target + remove legacy serialization support ctor

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,10 +15,12 @@ jobs:
         platform: [ windows-latest, ubuntu-latest, macos-14 ]
     steps:
     - uses: actions/checkout@v4
-    - name: Setup .NET Core 8.0
+    - name: Setup .NET 8.0 and 9.0
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 8.0.x
+        dotnet-version: |
+          8.0.x
+          9.0.x
     - name: Install dependencies
       run: dotnet restore Messaging.sln
     - name: Build

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -27,6 +27,12 @@ jobs:
         # https://docs.github.com/en/free-pro-team@latest/github/finding-security-vulnerabilities-and-errors-in-your-code/configuring-code-scanning#changing-the-languages-that-are-analyzed
 
     steps:
+
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: 9.0.x
+
     - name: Checkout repository
       uses: actions/checkout@v4
 
@@ -52,9 +58,7 @@ jobs:
     #    and modify them (or add more) to build your code if your project
     #    uses a compiled language
 
-    #- run: |
-    #   make bootstrap
-    #   make release
+    # - run: dotnet build Messaging.sln
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v3

--- a/.github/workflows/nuget-deploy.yml
+++ b/.github/workflows/nuget-deploy.yml
@@ -9,10 +9,10 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Setup .NET Core 8.0
+      - name: Setup .NET 9.0
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 8.0.x
+          dotnet-version: 9.0.x
       - name: Build
         run: |
           dotnet pack "./src/Helsenorge.Messaging/Helsenorge.Messaging.csproj" -c Release

--- a/src/Helsenorge.Messaging.AdminLib/Helsenorge.Messaging.AdminLib.csproj
+++ b/src/Helsenorge.Messaging.AdminLib/Helsenorge.Messaging.AdminLib.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
+        <TargetFrameworks>net6.0;net8.0;net9.0</TargetFrameworks>
         <ImplicitUsings>disable</ImplicitUsings>
         <Nullable>disable</Nullable>
     </PropertyGroup>

--- a/src/Helsenorge.Messaging/Amqp/Receivers/HeaderValidationException.cs
+++ b/src/Helsenorge.Messaging/Amqp/Receivers/HeaderValidationException.cs
@@ -28,11 +28,5 @@ namespace Helsenorge.Messaging.Amqp.Receivers
         public HeaderValidationException(string message, Exception inner) : base(message, inner)
         {
         }
-
-        protected HeaderValidationException(
-            SerializationInfo info,
-            StreamingContext context) : base(info, context)
-        {
-        }
     }
 }

--- a/src/Helsenorge.Messaging/Amqp/Receivers/ReceivedDataMismatchException.cs
+++ b/src/Helsenorge.Messaging/Amqp/Receivers/ReceivedDataMismatchException.cs
@@ -66,14 +66,5 @@ namespace Helsenorge.Messaging.Amqp.Receivers
         /// <param name="message"></param>
         /// <param name="inner"></param>
         public ReceivedDataMismatchException(string message, Exception inner) : base(message, inner) { }
-        /// <summary>
-        /// Constructor
-        /// </summary>
-        /// <param name="info"></param>
-        /// <param name="context"></param>
-        protected ReceivedDataMismatchException(
-          System.Runtime.Serialization.SerializationInfo info,
-          System.Runtime.Serialization.StreamingContext context)
-            : base(info, context) { }
     }
 }

--- a/src/Helsenorge.Messaging/Amqp/Receivers/UnsupportedMessageException.cs
+++ b/src/Helsenorge.Messaging/Amqp/Receivers/UnsupportedMessageException.cs
@@ -43,15 +43,5 @@ namespace Helsenorge.Messaging.Amqp.Receivers
         public UnsupportedMessageException(string message, Exception innerException) : base(message, innerException)
         {
         }
-
-        /// <summary>Initializes a new instance of the <see cref="UnsupportedMessageException" /> class with serialized data.</summary>
-        /// <param name="info">The <see cref="T:System.Runtime.Serialization.SerializationInfo" /> that holds the serialized object data about the exception being thrown.</param>
-        /// <param name="context">The <see cref="T:System.Runtime.Serialization.StreamingContext" /> that contains contextual information about the source or destination.</param>
-        /// <exception cref="T:System.ArgumentNullException">
-        /// <paramref name="info" /> is <see langword="null" />.</exception>
-        /// <exception cref="T:System.Runtime.Serialization.SerializationException">The class name is <see langword="null" /> or <see cref="P:System.Exception.HResult" /> is zero (0).</exception>
-        protected UnsupportedMessageException(SerializationInfo info, StreamingContext context) : base(info, context)
-        {
-        }
     }
 }

--- a/src/Helsenorge.Messaging/Amqp/ReportableErrorException.cs
+++ b/src/Helsenorge.Messaging/Amqp/ReportableErrorException.cs
@@ -32,15 +32,5 @@ namespace Helsenorge.Messaging.Amqp
         /// <param name="message"></param>
         /// <param name="inner"></param>
         public NotifySenderException(string message, Exception inner) : base(message, inner) { }
-        /// <summary>
-        /// 
-        /// </summary>
-        /// <param name="info"></param>
-        /// <param name="context"></param>
-        protected NotifySenderException(
-          SerializationInfo info,
-          StreamingContext context)
-            : base(info, context) { }
-
     }
 }

--- a/src/Helsenorge.Messaging/Helsenorge.Messaging.csproj
+++ b/src/Helsenorge.Messaging/Helsenorge.Messaging.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0;net8.0;net9.0</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
     <AssemblyName>Helsenorge.Messaging</AssemblyName>
     <RootNamespace>Helsenorge.Messaging</RootNamespace>

--- a/src/Helsenorge.Registries/Helsenorge.Registries.csproj
+++ b/src/Helsenorge.Registries/Helsenorge.Registries.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0;net8.0;net9.0</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
     <AssemblyName>Helsenorge.Registries</AssemblyName>
     <RootNamespace>Helsenorge.Registries</RootNamespace>
@@ -38,7 +38,7 @@
     <PackageReference Include="System.ServiceModel.Security" Version="6.0.0" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0' Or '$(TargetFramework)' == 'net9.0'">
     <PackageReference Include="System.ServiceModel.Http" Version="8.1.1" />
     <PackageReference Include="System.ServiceModel.NetTcp" Version="8.1.1" />
     <PackageReference Include="System.ServiceModel.Security" Version="6.0.0" />

--- a/test/Helsenorge.Messaging.AdminLib.Tests/Helsenorge.Messaging.AdminLib.Tests.csproj
+++ b/test/Helsenorge.Messaging.AdminLib.Tests/Helsenorge.Messaging.AdminLib.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
         <ImplicitUsings>disable</ImplicitUsings>
         <Nullable>disable</Nullable>
     </PropertyGroup>

--- a/test/Helsenorge.Messaging.Tests.Mocks/Helsenorge.Messaging.Tests.Mocks.csproj
+++ b/test/Helsenorge.Messaging.Tests.Mocks/Helsenorge.Messaging.Tests.Mocks.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
         <ImplicitUsings>disable</ImplicitUsings>
         <Nullable>disable</Nullable>
     </PropertyGroup>

--- a/test/Helsenorge.Messaging.Tests/Helsenorge.Messaging.Tests.csproj
+++ b/test/Helsenorge.Messaging.Tests/Helsenorge.Messaging.Tests.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
         <LangVersion>10.0</LangVersion>
         <AssemblyName>Helsenorge.Messaging.Tests</AssemblyName>
         <RootNamespace>Helsenorge.Messaging.Tests</RootNamespace>

--- a/test/Helsenorge.Registries.Tests/Helsenorge.Registries.Tests.csproj
+++ b/test/Helsenorge.Registries.Tests/Helsenorge.Registries.Tests.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
         <AssemblyName>Helsenorge.Registries.Tests</AssemblyName>
         <RootNamespace>Helsenorge.Registries.Tests</RootNamespace>
         <ProjectGuid>{0DD35E31-7384-4F3D-BBE0-366993DC2307}</ProjectGuid>


### PR DESCRIPTION
We still have the targets for netstandard2.0 (net462), net6.0, net8.0.