### PR TITLE
Default close timeout is 60s which delays message sending

### DIFF
--- a/Directory.build.props
+++ b/Directory.build.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <LangVersion>10.0</LangVersion>
-    <Version>6.0.4-beta01</Version>
+    <Version>6.0.4-beta02</Version>
   </PropertyGroup>
   <PropertyGroup>
     <Authors>Norsk Helsenett SF</Authors>

--- a/src/Helsenorge.Messaging/Amqp/CachedAmpqSessionEntity.cs
+++ b/src/Helsenorge.Messaging/Amqp/CachedAmpqSessionEntity.cs
@@ -21,6 +21,8 @@ namespace Helsenorge.Messaging.Amqp
         protected ISession _session;
         protected TLink _link;
         
+        private static readonly TimeSpan DefaultCloseTimeout = TimeSpan.FromSeconds(3);
+
         private readonly SemaphoreSlim _mySemaphoreSlim = new SemaphoreSlim(1);
         private readonly object _lockObject = new object();
 
@@ -120,7 +122,8 @@ namespace Helsenorge.Messaging.Amqp
             if (_session != null && !_session.IsClosed)
             {
                 await OnSessionClosingAsync().ConfigureAwait(false);
-                await _session.CloseAsync().ConfigureAwait(false);
+
+                await _session.CloseAsync(DefaultCloseTimeout, null).ConfigureAwait(false);
             }
         }
     }


### PR DESCRIPTION
Sending messages occasionally reports "The operation close did not complete within the allocated time 60000 for object Session" and sending the message (async or sync) is delayed for 60s which gives timeouts in calling services. This fix reduses the timeout to give sending the message time to complete within reasonable timeouts