### PR TITLE
Registries: Move from IdentityModel to Duende.IdentityModel

### DIFF
--- a/src/Helsenorge.Registries/Connected Services/HelseId/HelseIdClient.cs
+++ b/src/Helsenorge.Registries/Connected Services/HelseId/HelseIdClient.cs
@@ -11,8 +11,8 @@ using System.IdentityModel.Tokens.Jwt;
 using System.Net.Http;
 using System.Threading.Tasks;
 using Helsenorge.Registries.Configuration;
-using IdentityModel;
-using IdentityModel.Client;
+using Duende.IdentityModel;
+using Duende.IdentityModel.Client;
 using Microsoft.IdentityModel.Tokens;
 
 namespace Helsenorge.Registries.HelseId;

--- a/src/Helsenorge.Registries/Helsenorge.Registries.csproj
+++ b/src/Helsenorge.Registries/Helsenorge.Registries.csproj
@@ -20,7 +20,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="IdentityModel" Version="7.0.0" />
+    <PackageReference Include="Duende.IdentityModel" Version="7.1.0" />
     <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="9.0.9" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.9" />
     <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="8.14.0" />

--- a/src/Helsenorge.Registries/Utilities/RestServiceInvoker.cs
+++ b/src/Helsenorge.Registries/Utilities/RestServiceInvoker.cs
@@ -12,7 +12,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Net.Http;
 using System.Threading.Tasks;
 using Helsenorge.Registries.Configuration;
-using IdentityModel.Client;
+using Duende.IdentityModel.Client;
 using Microsoft.Extensions.Logging;
 
 namespace Helsenorge.Registries.Utilities;


### PR DESCRIPTION
Moves us from the now deprecated library IdenityModel to Duende.IdentiyModel. These libraries are identitcal and is more of a namespace change than anything else.