### PR TITLE
Upgrade of System.Security.Cryptography.Xml to 8.0.3

### DIFF
--- a/Directory.build.props
+++ b/Directory.build.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <LangVersion>10.0</LangVersion>
-      <Version>7.0.0</Version>
+      <Version>7.0.1</Version>
   </PropertyGroup>
   <PropertyGroup>
     <Authors>Norsk Helsenett SF</Authors>

--- a/src/Helsenorge.Registries/Helsenorge.Registries.csproj
+++ b/src/Helsenorge.Registries/Helsenorge.Registries.csproj
@@ -24,6 +24,7 @@
     <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="10.0.5" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.5" />
     <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="8.16.0" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.3" />
   </ItemGroup>
   
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0' Or '$(TargetFramework)' == 'net9.0'">


### PR DESCRIPTION
- Added reference to System.Security.Cryptography.Xml 8.0.3 in Helsenorge.Registries so it explicit uses this version
- Bumped version to 7.0.1