### PR TITLE
Enhance certificate handling in SignThenEncryptMessageProtection

### DIFF
--- a/src/Helsenorge.Messaging/Security/SignThenEncryptMessageProtection.cs
+++ b/src/Helsenorge.Messaging/Security/SignThenEncryptMessageProtection.cs
@@ -1,7 +1,7 @@
-﻿/* 
+﻿/*
  * Copyright (c) 2020-2024, Norsk Helsenett SF and contributors
  * See the file CONTRIBUTORS for details.
- * 
+ *
  * This file is licensed under the MIT license
  * available at https://raw.githubusercontent.com/helsenorge/Helsenorge.Messaging/master/LICENSE
  */
@@ -9,12 +9,14 @@
 using System;
 using System.IO;
 using System.Security;
-using System.Security.Cryptography.X509Certificates;
-using System.Security.Cryptography.Pkcs;
-using Helsenorge.Messaging.Abstractions;
 using System.Security.Cryptography;
-using Microsoft.Extensions.Logging;
+using System.Security.Cryptography.Pkcs;
+using System.Security.Cryptography.X509Certificates;
+using System.Security.Cryptography.Xml;
+using System.Text;
+using Helsenorge.Messaging.Abstractions;
 using Helsenorge.Messaging.Amqp.Receivers;
+using Microsoft.Extensions.Logging;
 
 namespace Helsenorge.Messaging.Security
 {
@@ -31,7 +33,7 @@ namespace Helsenorge.Messaging.Security
         /// <summary>
         /// Initializes a new instance of the <see cref="SignThenEncryptMessageProtection"/> class with the required certificates for signing and encrypting data.
         /// </summary>
-        /// <param name="signingCertificate">Certificcate that will be used to sign data</param>
+        /// <param name="signingCertificate">Certificate that will be used to sign data</param>
         /// <param name="encryptionCertificate">Certificate that will be used to encrypt data</param>
         /// <param name="logger"></param>
         /// <param name="legacyEncryptionCertificate">A legacy certificate that can be used when swapping certificates.</param>
@@ -151,12 +153,14 @@ namespace Helsenorge.Messaging.Security
 
                 envelopedCms.Decrypt(envelopedCms.RecipientInfos[0], encryptionCertificates);
             }
-            catch (System.Security.Cryptography.CryptographicException ce)
+            catch (CryptographicException ce)
             {
-                var cert = envelopedCms?.RecipientInfos[0]?.RecipientIdentifier?.Value as System.Security.Cryptography.Xml.X509IssuerSerial?;
+                var cert = envelopedCms?.RecipientInfos[0]?.RecipientIdentifier?.Value as X509IssuerSerial?;
                 if (cert.HasValue)
+                {
                     throw new SecurityException($"Message encrypted with certificate SerialNumber {cert.Value.SerialNumber}, IssueName {cert.Value.IssuerName} " +
-                                            $"could not be decrypted. Certification details: {cert} Exception: {ce.Message}");
+                                                $"could not be decrypted. Certification details: {cert} Exception: {ce.Message}");
+                }
 
                 throw new SecurityException($"Encryption certificate not found. Exception: {ce.Message}");
             }
@@ -169,17 +173,29 @@ namespace Helsenorge.Messaging.Security
 
             // there have been cases when the sender doesn't specify a FromHerId; makes it impossible to find the signature certificate
             // the decryption certificate will be ours, so we since we sign first, we can decrypt the data and see if that gives us any clues
-            // if no decryption certicate has been provided, we assume we don't have valid certificate
+            // if no decryption certificate has been provided, we assume we don't have valid certificate
             if (signingCertificate != null)
             {
                 // check if the certificate is in the list of certificates used to sign the package
-                // there may be more than one; have seen the root certificate being included some times
+                // there may be more than one; have seen the root/intermediate CA certificate(s) being included some times
                 if (signedCms.Certificates.Find(X509FindType.FindBySerialNumber, signingCertificate.SerialNumber, false).Count == 0)
                 {
-                    var actualSignedCertificate = signedCms.Certificates.Count > 0
-                        ? signedCms.Certificates[signedCms.Certificates.Count - 1] : null;
+                    /*
+                        The SignedCms.Certificates collection can contain more than one certificate (senders sometimes bundle the root/intermediate CA certificates). 
+                        Simply taking the last certificate in the collection is unreliable, since it is often a CA/root
+                        certificate (e.g. Buypass) rather than the actual end-entity signing certificate.
+                    */
+                    var actualSignedCertificate = ResolveActualSigningCertificate(signedCms);
 
-                    // it looks like that last certificate in the collection is the one at the end of the chain
+                    // Log every certificate that was included so we can diagnose what the sender actually sent.
+                    if (_logger != null && signedCms.Certificates.Count > 0)
+                    {
+                        _logger.LogWarning(
+                            $"Expected signing certificate was not found in the message. " +
+                            $"The message included {signedCms.Certificates.Count} certificate(s): " +
+                            $"{Environment.NewLine}{DescribeCertificates(signedCms.Certificates)}");
+                    }
+
                     throw new CertificateMessagePayloadException(
                         $"Expected signingcertificate: {Environment.NewLine} {signingCertificate} {Environment.NewLine}{Environment.NewLine}" +
                         $"Actual signingcertificate: {Environment.NewLine} {actualSignedCertificate} {Environment.NewLine}{Environment.NewLine}",
@@ -190,6 +206,76 @@ namespace Helsenorge.Messaging.Security
             }
             // Return the raw content (without a signature).
             return signedCms.ContentInfo.Content;
+        }
+
+        /// <summary>
+        /// Determines which certificate was actually used to sign the message.
+        /// The <see cref="SignedCms.Certificates"/> collection may contain more than one certificate,
+        /// e.g. when a sender bundles the root/intermediate CA certificates together with the
+        /// end-entity signing certificate. This method resolves the real signer instead of
+        /// blindly picking the last certificate in the collection.
+        /// </summary>
+        internal static X509Certificate2 ResolveActualSigningCertificate(SignedCms signedCms)
+        {
+            if (signedCms.Certificates.Count == 0)
+            {
+                return null;
+            }
+
+            // Prefer the certificate that the SignerInfo actually points to. This is the most reliable source, as it is derived from the signature itself.
+            foreach (SignerInfo signerInfo in signedCms.SignerInfos)
+            {
+                if (signerInfo.Certificate != null)
+                {
+                    return signerInfo.Certificate;
+                }
+            }
+
+            // Fall back to the first end-entity (non-CA) certificate. Root/intermediate CA certificates (e.g. Buypass) are excluded so we report the leaf/signing certificate.
+            foreach (var certificate in signedCms.Certificates)
+            {
+                if (!IsCertificateAuthority(certificate))
+                {
+                    return certificate;
+                }
+            }
+
+            // 3. As a last resort keep the previous behaviour and return the last certificate.
+            return signedCms.Certificates[signedCms.Certificates.Count - 1];
+        }
+
+        /// <summary>
+        /// Returns <c>true</c> if the certificate is a CA (root or intermediate) certificate.
+        /// </summary>
+        internal static bool IsCertificateAuthority(X509Certificate2 certificate)
+        {
+            foreach (var extension in certificate.Extensions)
+            {
+                if (extension is X509BasicConstraintsExtension basicConstraints)
+                {
+                    return basicConstraints.CertificateAuthority;
+                }
+            }
+
+            // No BasicConstraints extension: treat a self-issued certificate as a root/CA certificate.
+            return string.Equals(certificate.SubjectName.Name, certificate.IssuerName.Name, StringComparison.OrdinalIgnoreCase);
+        }
+
+        /// <summary>
+        /// Builds a human-readable description of all certificates in the collection for diagnostics.
+        /// </summary>
+        private static string DescribeCertificates(X509Certificate2Collection certificates)
+        {
+            var builder = new StringBuilder();
+            var index = 0;
+            foreach (var certificate in certificates)
+            {
+                builder.AppendLine(
+                    $"[{index++}] Subject: {certificate.Subject}, Issuer: {certificate.Issuer}, " +
+                    $"SerialNumber: {certificate.SerialNumber}, Thumbprint: {certificate.Thumbprint}, " +
+                    $"IsCertificateAuthority: {IsCertificateAuthority(certificate)}");
+            }
+            return builder.ToString();
         }
 
         private EnvelopedCms GetEnvelope(byte[] rawContent)

--- a/test/Helsenorge.Messaging.Tests/Security/SignThenEncryptMessageProtectionTests.cs
+++ b/test/Helsenorge.Messaging.Tests/Security/SignThenEncryptMessageProtectionTests.cs
@@ -1,7 +1,7 @@
-﻿/* 
+﻿/*
  * Copyright (c) 2020-2023, Norsk Helsenett SF and contributors
  * See the file CONTRIBUTORS for details.
- * 
+ *
  * This file is licensed under the MIT license
  * available at https://raw.githubusercontent.com/helsenorge/Helsenorge.Messaging/master/LICENSE
  */
@@ -9,6 +9,8 @@
 using System;
 using System.IO;
 using System.Security;
+using System.Security.Cryptography;
+using System.Security.Cryptography.Pkcs;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
 using System.Xml.Linq;
@@ -152,6 +154,89 @@ namespace Helsenorge.Messaging.Tests.Security
             var result = partyBProtection.Unprotect(stream, null);
 
             Assert.AreEqual(_content.ToString(), result.ToXDocument().ToString());
+        }
+
+        [TestMethod]
+        public void IsCertificateAuthority_WithBasicConstraintsCaTrue_ReturnsTrue()
+        {
+            using var caCertificate = CreateCertificate("CN=Test Buypass Class 3 CA 3", isCertificateAuthority: true);
+
+            Assert.IsTrue(SignThenEncryptMessageProtection.IsCertificateAuthority(caCertificate));
+        }
+
+        [TestMethod]
+        public void IsCertificateAuthority_WithBasicConstraintsCaFalse_ReturnsFalse()
+        {
+            using var leafCertificate = CreateCertificate("CN=Test Norsk Helsenett", isCertificateAuthority: false);
+
+            Assert.IsFalse(SignThenEncryptMessageProtection.IsCertificateAuthority(leafCertificate));
+        }
+
+        [TestMethod]
+        public void IsCertificateAuthority_SelfIssuedWithoutBasicConstraints_ReturnsTrue()
+        {
+            // A self-issued certificate (Subject == Issuer) without a BasicConstraints extension
+            // should be treated as a root/CA certificate.
+            using var selfIssued = CreateCertificate("CN=Test Root", isCertificateAuthority: null);
+
+            Assert.IsTrue(SignThenEncryptMessageProtection.IsCertificateAuthority(selfIssued));
+        }
+
+        [TestMethod]
+        public void ResolveActualSigningCertificate_UsesSignerInfo_WhenRootIsBundled()
+        {
+            // The message is signed by the leaf certificate, but the sender also bundles the root CA certificate. The old logic returned the last certificate in the collection (the root); the new logic must return the actual signer (the leaf).
+            using var leafCertificate = CreateCertificate("CN=Test Norsk Helsenett Signing", isCertificateAuthority: false);
+            using var rootCertificate = CreateCertificate("CN=Test Buypass Class 3 CA 3", isCertificateAuthority: true);
+
+            var signedCms = new SignedCms(new ContentInfo(Encoding.UTF8.GetBytes(_content.ToString())));
+            var signer = new CmsSigner(leafCertificate) { IncludeOption = X509IncludeOption.EndCertOnly };
+            signedCms.ComputeSignature(signer);
+            // Simulate the sender bundling the root certificate in addition to the leaf.
+            signedCms.AddCertificate(rootCertificate);
+
+            var actual = SignThenEncryptMessageProtection.ResolveActualSigningCertificate(signedCms);
+
+            Assert.IsNotNull(actual);
+            Assert.AreEqual(leafCertificate.Thumbprint, actual.Thumbprint);
+        }
+
+        [TestMethod]
+        public void ResolveActualSigningCertificate_FallsBackToNonCaCertificate_WhenSignerNotEmbedded()
+        {
+            // When the signer certificate is not embedded in the message (SignerInfo.Certificate is null)
+            // and both a CA and an end-entity certificate are bundled, we should report the non-CA (leaf) one.
+            using var signingCertificate = CreateCertificate("CN=Test Signer Not Embedded", isCertificateAuthority: false);
+            using var otherLeafCertificate = CreateCertificate("CN=Test Other Leaf", isCertificateAuthority: false);
+            using var rootCertificate = CreateCertificate("CN=Test Buypass Class 3 CA 3", isCertificateAuthority: true);
+
+            var signedCms = new SignedCms(new ContentInfo(Encoding.UTF8.GetBytes(_content.ToString())));
+            var signer = new CmsSigner(signingCertificate) { IncludeOption = X509IncludeOption.None };
+            signedCms.ComputeSignature(signer);
+            // The signer certificate is intentionally NOT added; only the root and an unrelated leaf are bundled.
+            signedCms.AddCertificate(rootCertificate);
+            signedCms.AddCertificate(otherLeafCertificate);
+
+            var actual = SignThenEncryptMessageProtection.ResolveActualSigningCertificate(signedCms);
+
+            Assert.IsNotNull(actual);
+            Assert.AreEqual(otherLeafCertificate.Thumbprint, actual.Thumbprint);
+            Assert.AreNotEqual(rootCertificate.Thumbprint, actual.Thumbprint);
+        }
+
+        private static X509Certificate2 CreateCertificate(string subjectName, bool? isCertificateAuthority)
+        {
+            using var rsa = RSA.Create(2048);
+            var request = new CertificateRequest(subjectName, rsa, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+
+            // isCertificateAuthority == null means "do not add a BasicConstraints extension at all".
+            if (isCertificateAuthority.HasValue)
+            {
+                request.CertificateExtensions.Add(
+                    new X509BasicConstraintsExtension(isCertificateAuthority.Value, false, 0, true));
+            }
+
+            return request.CreateSelfSigned(DateTimeOffset.UtcNow.AddDays(-1), DateTimeOffset.UtcNow.AddDays(1));
         }
     }
 }


### PR DESCRIPTION
- Improved error messages for decryption failures.
- Added logging for missing signing certificates.
- Implemented logic to accurately resolve the actual signing certificate from bundled certificates.
- Introduced utility methods to determine if a certificate is a CA and to describe certificates for diagnostics.
- Added unit tests for new certificate resolution logic and authority checks.

NHN ADO ref: 375726