### PR TITLE
Refactor error message handling to create unique messages instead of cloning, improving error reporting accuracy

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,0 +1,7 @@
+{
+  "sdk": {
+    "version": "8.0.0",
+    "rollForward": "latestMajor",
+    "allowPrerelease": true
+  }
+}

--- a/src/Helsenorge.Messaging/Amqp/AmqpCore.cs
+++ b/src/Helsenorge.Messaging/Amqp/AmqpCore.cs
@@ -10,6 +10,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
+using System.IO;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
 using System.Threading.Tasks;
@@ -378,36 +379,30 @@ namespace Helsenorge.Messaging.Amqp
                 logger.LogWarning(EventIds.MissingField, "FromHerId is missing. No idea where to send the error");
                 return;
             }
+            /*
+                Build a brand new, unique error message instead of cloning the original.
+                Cloning carries over broker-managed headers, delivery-/message-annotations
+                (e.g. x-opt-locked-until) and other transport state that causes follow-on
+                errors when the message is re-sent. We only set the properties defined by the documentation.           
+            */
+            var errorMessage = await FactoryPool.CreateMessageAsync(logger, new MemoryStream()).ConfigureAwait(false);
 
-            // Clones original message, but leaves out the payload
-            var clonedMessage = originalMessage.Clone(false);
-            // update some properties on the cloned message
-            clonedMessage.To = await ConstructQueueNameAsync(logger, originalMessage.FromHerId, QueueType.Error)
-                .ConfigureAwait(false); // change target 
-            clonedMessage.TimeToLive = Settings.Error.TimeToLive;
-            clonedMessage.FromHerId = originalMessage.ToHerId;
-            clonedMessage.ToHerId = originalMessage.FromHerId;
+            errorMessage.MessageId = Guid.NewGuid().ToString("N");
+            errorMessage.MessageFunction = originalMessage.MessageFunction;
+            errorMessage.To = await ConstructQueueNameAsync(logger, originalMessage.FromHerId, QueueType.Error)
+                .ConfigureAwait(false); // send to the sender's error queue
+            errorMessage.TimeToLive = Settings.Error.TimeToLive;
+           
+            // the error travels in the opposite direction of the original message
+            errorMessage.FromHerId = originalMessage.ToHerId;
+            errorMessage.ToHerId = originalMessage.FromHerId;
+            errorMessage.ApplicationTimestamp = DateTime.UtcNow;
 
-            if (clonedMessage.Properties.ContainsKey(OriginalMessageIdHeaderKey) == false)
-            {
-                clonedMessage.SetApplicationPropertyValue(OriginalMessageIdHeaderKey, originalMessage.MessageId);
-            }
-
-            if (clonedMessage.Properties.ContainsKey(ReceiverTimestampHeaderKey) == false)
-            {
-                clonedMessage.SetApplicationPropertyValue(ReceiverTimestampHeaderKey,
-                    DateTime.UtcNow.ToString(DateTimeFormatInfo.InvariantInfo));
-            }
-
-            if (clonedMessage.Properties.ContainsKey(ErrorConditionHeaderKey) == false)
-            {
-                clonedMessage.SetApplicationPropertyValue(ErrorConditionHeaderKey, errorCode);
-            }
-
-            if (clonedMessage.Properties.ContainsKey(ErrorDescriptionHeaderKey) == false)
-            {
-                clonedMessage.SetApplicationPropertyValue(ErrorDescriptionHeaderKey, errorDescription);
-            }
+            errorMessage.SetApplicationPropertyValue(OriginalMessageIdHeaderKey, originalMessage.MessageId);
+            errorMessage.SetApplicationPropertyValue(ReceiverTimestampHeaderKey,
+                DateTime.UtcNow.ToString(DateTimeFormatInfo.InvariantInfo));
+            errorMessage.SetApplicationPropertyValue(ErrorConditionHeaderKey, errorCode);
+            errorMessage.SetApplicationPropertyValue(ErrorDescriptionHeaderKey, errorDescription);
 
             var additionDataValue = "None";
             if (additionalData != null)
@@ -424,23 +419,19 @@ namespace Helsenorge.Messaging.Amqp
 
                 additionDataValue = sb.ToString();
 
-                if (clonedMessage.Properties.ContainsKey(ErrorConditionDataHeaderKey) == false)
-                {
-                    clonedMessage.SetApplicationPropertyValue(ErrorConditionDataHeaderKey, additionDataValue);
-                }
+                errorMessage.SetApplicationPropertyValue(ErrorConditionDataHeaderKey, additionDataValue);
             }
-
 
             logger.LogWarning(
                 "Reporting error to sender. FromHerId: {0} ToHerId: {1} ErrorCode: {2} ErrorDescription: {3} AdditionalData: {4}",
                 originalMessage.FromHerId, originalMessage.ToHerId, errorCode, errorDescription, additionDataValue);
 
-            logger.LogStartSend(QueueType.Error, clonedMessage.MessageFunction, clonedMessage.FromHerId,
-                clonedMessage.ToHerId, clonedMessage.MessageId, additionDataValue, null);
-            await SendAsync(logger, clonedMessage).ConfigureAwait(false);
+            logger.LogStartSend(QueueType.Error, errorMessage.MessageFunction, errorMessage.FromHerId,
+                errorMessage.ToHerId, errorMessage.MessageId, additionDataValue, null);
+            await SendAsync(logger, errorMessage).ConfigureAwait(false);
             stopwatch.Stop();
-            logger.LogEndSend(QueueType.Error, clonedMessage.MessageFunction, clonedMessage.FromHerId,
-                clonedMessage.ToHerId, clonedMessage.MessageId, stopwatch.ElapsedMilliseconds);
+            logger.LogEndSend(QueueType.Error, errorMessage.MessageFunction, errorMessage.FromHerId,
+                errorMessage.ToHerId, errorMessage.MessageId, stopwatch.ElapsedMilliseconds);
         }
 
         /// <summary>

--- a/src/Helsenorge.Messaging/Amqp/LoggingExtensions.cs
+++ b/src/Helsenorge.Messaging/Amqp/LoggingExtensions.cs
@@ -1,15 +1,15 @@
-﻿/* 
+﻿/*
  * Copyright (c) 2020-2024, Norsk Helsenett SF and contributors
  * See the file CONTRIBUTORS for details.
- * 
+ *
  * This file is licensed under the MIT license
  * available at https://raw.githubusercontent.com/helsenorge/Helsenorge.Messaging/master/LICENSE
  */
 
-using Microsoft.Extensions.Logging;
 using System;
 using System.Xml.Linq;
 using Helsenorge.Messaging.Abstractions;
+using Microsoft.Extensions.Logging;
 
 namespace Helsenorge.Messaging.Amqp
 {
@@ -18,6 +18,7 @@ namespace Helsenorge.Messaging.Amqp
         private static readonly Action<ILogger, QueueType, string, int, int, string, string, Exception> StartReceive;
         private static readonly Action<ILogger, QueueType, string, int, int, string, long, Exception> EndReceive;
         private static readonly Action<ILogger, QueueType, string, int, int, string, string, Exception> StartSend;
+        private static readonly Action<ILogger, string, Exception> StartSendPayload;
         private static readonly Action<ILogger, QueueType, string, int, int, string, long, Exception> EndSend;
         private static readonly Action<ILogger, string, int, int, string, string, Exception> ResponseTime;
         private static readonly Action<ILogger, string, string, int, Exception> LogTimeout;
@@ -55,9 +56,9 @@ namespace Helsenorge.Messaging.Amqp
         public static void LogStartSend(this ILogger logger, QueueType queueType, string function, int fromHerId, int toHerId, string messageId, string additionalData, XDocument xml)
         {
             StartSend(logger, queueType, function, fromHerId, toHerId, messageId, additionalData, null);
-            if (xml != null)
+            if (xml != null && logger.IsEnabled(LogLevel.Debug))
             {
-                logger.LogDebug(xml.ToString());
+                StartSendPayload(logger, xml.ToString(), null);
             }
         }
         public static void LogEndSend(this ILogger logger, QueueType queueType, string function, int fromHerId, int toHerId, string messageId, long elapsedMilliseconds)
@@ -155,6 +156,11 @@ namespace Helsenorge.Messaging.Amqp
                 LogLevel.Information,
                 EventIds.ServiceBusSend,
                 "Start-ServiceBusSend{QueueType}: {MessageFunction} FromHerId: {FromHerId} ToHerId: {ToHerId} MessageId: {MessageId} Additional Data: {AdditionalData}");
+
+            StartSendPayload = LoggerMessage.Define<string>(
+                LogLevel.Debug,
+                EventIds.ServiceBusSend,
+                "Start-ServiceBusSend payload: {Xml}");
 
             EndSend = LoggerMessage.Define<QueueType, string, int, int, string, long>(
                 LogLevel.Information,


### PR DESCRIPTION
Refactor error message handling to create unique messages instead of cloning, improving error reporting accuracy

[Based on NHN-Documentation](https://helsenorge.atlassian.net/wiki/spaces/HELSENORGE/pages/1656651781/AMQP+Profil#Feilrapportering-p%C3%A5-AMQP-Error-k%C3%B8)